### PR TITLE
fix: upgrade geth version from 6 to 7

### DIFF
--- a/fhevm-engine/coprocessor/docker-compose.yml
+++ b/fhevm-engine/coprocessor/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - --server-addr=0.0.0.0:50051
       - --coprocessor-private-key=/usr/share/coprocessor.key
   geth:
-    image: ghcr.io/zama-ai/geth-coprocessor-devnode:v6
+    image: ghcr.io/zama-ai/geth-coprocessor-devnode:v7
     environment:
       - FHEVM_COPROCESSOR_API_KEY=a1503fb6-d79b-4e9e-826d-44cf262f3e05
       - FHEVM_COPROCESSOR_URL=coproc:50051


### PR DESCRIPTION
- This docker image of geth include the fix for consider types bigger than FheUint160 valid.

- More specifically, it fixes error in processing uint256 type.