### PR TITLE
feat: Use config.service-name in coprocessor OTLP traces

### DIFF
--- a/docs/getting_started/fhevm/coprocessor/configuration.md
+++ b/docs/getting_started/fhevm/coprocessor/configuration.md
@@ -64,6 +64,8 @@ Options:
           Postgres database url. If unspecified DATABASE_URL environment variable is used
       --coprocessor-private-key <COPROCESSOR_PRIVATE_KEY>
           Coprocessor private key file path. Private key is in plain text 0x1234.. format [default: ./coprocessor.key]
+      --service-name <SERVICE_NAME>
+          Coprocessor service name in OTLP traces [default: coprocessor]
   -h, --help
           Print help
   -V, --version

--- a/fhevm-engine/Cargo.lock
+++ b/fhevm-engine/Cargo.lock
@@ -1772,6 +1772,7 @@ dependencies = [
  "lru",
  "opentelemetry",
  "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prometheus",
  "prost",
@@ -3508,6 +3509,12 @@ dependencies = [
  "prost",
  "tonic",
 ]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
 
 [[package]]
 name = "opentelemetry_sdk"

--- a/fhevm-engine/coprocessor/Cargo.toml
+++ b/fhevm-engine/coprocessor/Cargo.toml
@@ -30,6 +30,7 @@ lru = "0.12.3"
 opentelemetry = "0.25.0"
 opentelemetry-otlp = "0.25.0"
 opentelemetry_sdk = { version = "0.25.0", features = ["rt-tokio"] }
+opentelemetry-semantic-conventions = "0.27.0"
 regex = "1.10.5"
 serde_json = "1.0"
 strum = { version = "0.26", features = ["derive"] }

--- a/fhevm-engine/coprocessor/src/daemon_cli.rs
+++ b/fhevm-engine/coprocessor/src/daemon_cli.rs
@@ -71,6 +71,10 @@ pub struct Args {
     /// Private key is in plain text 0x1234.. format.
     #[arg(long, default_value = "./coprocessor.key")]
     pub coprocessor_private_key: String,
+
+    /// Coprocessor service name in OTLP traces
+    #[arg(long, default_value = "coprocessor")]
+    pub service_name: String,
 }
 
 pub fn parse_args() -> Args {

--- a/fhevm-engine/coprocessor/src/lib.rs
+++ b/fhevm-engine/coprocessor/src/lib.rs
@@ -56,7 +56,9 @@ pub async fn async_main(
         tracing_subscriber::fmt().json().with_level(true).init();
     });
 
-    if let Err(err) = tracing::setup_tracing() {
+    info!(target: "async_main", "Starting runtime with args: {:?}", args);
+
+    if let Err(err) = tracing::setup_tracing(&args.service_name) {
         panic!("Error while initializing tracing: {:?}", err);
     }
 

--- a/fhevm-engine/coprocessor/src/tests/utils.rs
+++ b/fhevm-engine/coprocessor/src/tests/utils.rs
@@ -101,6 +101,7 @@ async fn start_coprocessor(rx: Receiver<bool>, app_port: u16, db_url: &str) {
         database_url: Some(db_url.to_string()),
         maximimum_compact_inputs_upload: 10,
         coprocessor_private_key: "./coprocessor.key".to_string(),
+        service_name: "coprocessor".to_string(),
     };
 
     std::thread::spawn(move || {

--- a/fhevm-engine/coprocessor/src/tracing.rs
+++ b/fhevm-engine/coprocessor/src/tracing.rs
@@ -1,9 +1,19 @@
-pub fn setup_tracing() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::Resource;
+
+pub fn setup_tracing(service_name: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     let otlp_exporter = opentelemetry_otlp::new_exporter().tonic();
 
     let trace_provider = opentelemetry_otlp::new_pipeline()
         .tracing()
         .with_exporter(otlp_exporter)
+        .with_trace_config(
+            opentelemetry_sdk::trace::Config::default()
+                .with_resource(Resource::new(vec![KeyValue::new(
+                    opentelemetry_semantic_conventions::resource::SERVICE_NAME.to_string(),
+                    service_name.to_string(),
+                )])),
+        )
         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 
     opentelemetry::global::set_tracer_provider(trace_provider);


### PR DESCRIPTION
fixes #130 

- Add new CLI option `--service-name`
- Set the service name in setting OTLP traces service name

![traces](https://github.com/user-attachments/assets/54c2c8de-ccaa-410d-b670-61111f5fdaa5)

