### PR TITLE
feat(native): enhance traceability with additional logs for better debugging

### DIFF
--- a/fhevm-engine/fhevm-go-native/fhevm/fhelib.go
+++ b/fhevm-engine/fhevm-go-native/fhevm/fhelib.go
@@ -17,6 +17,13 @@ type FheLibMethod struct {
 	NonScalarDisabled bool
 }
 
+func (m FheLibMethod) String() string {
+	return fmt.Sprintf(
+		"FheLibMethod(Name: %s, ArgTypes: %s, ScalarSupport: %t, NonScalarDisabled: %t)",
+		m.Name, m.ArgTypes, m.ScalarSupport, m.NonScalarDisabled,
+	)
+}
+
 var signatureToFheLibMethod = map[uint32]*FheLibMethod{}
 
 func FheLibMethods() []*FheLibMethod {

--- a/fhevm-engine/fhevm-go-native/fhevm/logger.go
+++ b/fhevm-engine/fhevm-go-native/fhevm/logger.go
@@ -1,0 +1,128 @@
+package fhevm
+
+import (
+	"fmt"
+	"os"
+)
+
+// Map FheOp to its string representations
+var fheOpNames = map[FheOp]string{
+	FheAdd:         "FheAdd",
+	FheSub:         "FheSub",
+	FheMul:         "FheMul",
+	FheDiv:         "FheDiv",
+	FheRem:         "FheRem",
+	FheBitAnd:      "FheBitAnd",
+	FheBitOr:       "FheBitOr",
+	FheBitXor:      "FheBitXor",
+	FheShl:         "FheShl",
+	FheShr:         "FheShr",
+	FheRotl:        "FheRotl",
+	FheRotr:        "FheRotr",
+	FheEq:          "FheEq",
+	FheNe:          "FheNe",
+	FheGe:          "FheGe",
+	FheGt:          "FheGt",
+	FheLe:          "FheLe",
+	FheLt:          "FheLt",
+	FheMin:         "FheMin",
+	FheMax:         "FheMax",
+	FheNeg:         "FheNeg",
+	FheNot:         "FheNot",
+	FheCast:        "FheCast",
+	TrivialEncrypt: "TrivialEncrypt",
+	FheIfThenElse:  "FheIfThenElse",
+	FheRand:        "FheRand",
+	FheRandBounded: "FheRandBounded",
+}
+
+// String implements the fmt.Stringer interface for FheOp
+func (op FheOp) String() string {
+	if name, ok := fheOpNames[op]; ok {
+		return name
+	}
+	return fmt.Sprintf("UnknownFheOp(%d)", op)
+}
+
+// A FHELogger writes key/value pairs to a Handler
+type FHELogger interface {
+	Trace(msg string, ctx ...interface{})
+	Debug(msg string, ctx ...interface{})
+	Info(msg string, ctx ...interface{})
+	Warn(msg string, ctx ...interface{})
+	Error(msg string, ctx ...interface{})
+	Crit(msg string, ctx ...interface{})
+}
+
+// ProxyLogger is a concrete implementation of FHELogger that adds extra context to all calls.
+type ProxyLogger struct {
+	// logger is the underlying logger that ProxyLogger delegates to.
+	// This should be the concrete logger implementation of the Host
+	logger FHELogger
+	ctx    []interface{}
+}
+
+// log creates a new ProxyLogger instance with the given logger and context.
+func log(logger FHELogger, ctx ...interface{}) ProxyLogger {
+	return ProxyLogger{
+		logger: logger,
+		ctx:    ctx,
+	}
+}
+
+// Trace adds extra context and delegates the call.
+func (p *ProxyLogger) Trace(msg string, ctx ...interface{}) {
+	if p.logger == nil {
+		return
+	}
+
+	p.logger.Trace(msg, append(p.ctx, ctx...)...)
+}
+
+// Debug adds extra context and delegates the call.
+func (p *ProxyLogger) Debug(msg string, ctx ...interface{}) {
+	if p.logger == nil {
+		return
+	}
+
+	p.logger.Debug(msg, append(p.ctx, ctx...)...)
+}
+
+// Info adds extra context and delegates the call.
+func (p *ProxyLogger) Info(msg string, ctx ...interface{}) {
+	if p.logger == nil {
+		return
+	}
+
+	p.logger.Info(msg, append(p.ctx, ctx...)...)
+}
+
+// Warn adds extra context and delegates the call.
+func (p *ProxyLogger) Warn(msg string, ctx ...interface{}) {
+	if p.logger == nil {
+		return
+	}
+
+	p.logger.Warn(msg, append(p.ctx, ctx...)...)
+}
+
+// Error adds extra context and delegates the call.
+func (p *ProxyLogger) Error(msg string, ctx ...interface{}) {
+	if p.logger == nil {
+		return
+	}
+
+	p.logger.Error(msg, append(p.ctx, ctx...)...)
+}
+
+// Crit adds extra context and delegates the call.
+// It terminates the process after logging the message.
+// This is useful for fatal errors.
+func (p *ProxyLogger) Crit(msg string, ctx ...interface{}) {
+	if p.logger != nil {
+		p.logger.Crit(msg, append(p.ctx, ctx...)...)
+	}
+
+	// Exit the process
+	os.Exit(1)
+}


### PR DESCRIPTION
#### Summary
Simplifies debugging by adding trace logs for key actions such as `execute`, `commit`, `queue`, `flush`, and `compute`.

#### Changes
- Most traces are now logged at the `log.debug` level with a few in `log.info`.
- In Geth, enable debug-level logging using the `--verbosity 4` CLI parameter.

#### Examples for Filtering Logs
- `grep fhevm`: Display all FHEVM-related logs.
- `grep handle=59b4f9`: Filter logs by specific handle.
- `grep 'sync compute'`: Display input and output of `grpc.SyncCompute`.

```
DEBUG[12-18|12:21:25.859] Add operation                            module="fhevm:sync compute" op=FHE_TRIVIAL_ENCRYPT handle=59b4f9..500300
INFO [12-18|12:21:25.859] Sending grpc request                     module="fhevm:sync compute" computations=1 "compressed ciphertexts"=0
INFO [12-18|12:21:25.864] Response                                 module="fhevm:sync compute" "ciphertexts count"=1
DEBUG[12-18|12:21:25.864] Response ciphertext                      module="fhevm:sync compute" handle=59b4f9..500300 len=1866
DEBUG[12-18|12:21:25.864] Computations completed                   module="fhevm:sync compute" duration=5ms
```

- grep 'Insert computation' fhevm.log | grep 'CommitBlockId: 15' - Display computations inserted in Block height 10