### PR TITLE
fix(native): ensure buckets use valid references

### DIFF
--- a/fhevm-engine/fhevm-go-native/fhevm/api.go
+++ b/fhevm-engine/fhevm-go-native/fhevm/api.go
@@ -576,12 +576,13 @@ func (dbApi *EvmStorageComputationStore) InsertComputationBatch(evmStorage Chain
 	// his ciphertexts to be evaluated
 	buckets := make(map[int64][]*ComputationToInsert)
 	// index the buckets
-	for _, comp := range computations {
+	for ind, comp := range computations {
 		if buckets[comp.CommitBlockId] == nil {
 			buckets[comp.CommitBlockId] = make([]*ComputationToInsert, 0)
 		}
-		buckets[comp.CommitBlockId] = append(buckets[comp.CommitBlockId], &comp)
+		buckets[comp.CommitBlockId] = append(buckets[comp.CommitBlockId], &computations[ind])
 	}
+
 	// collect all their keys and sort because golang doesn't traverse map
 	// in deterministic order
 	allKeys := make([]int, 0)


### PR DESCRIPTION
fixes #201 

- Previously, the variables declared by a “for” loop were created once and updated by each iteration. In Go 1.22, each iteration of the loop creates new variables, to avoid accidental sharing bugs. The [transition support tooling](https://tip.golang.org/wiki/LoopvarExperiment#my-test-fails-with-the-change-how-can-i-debug-it) described in the proposal continues to work in the same way it did in Go 1.2
  - src: https://tip.golang.org/doc/go1.22

- Although, it's fixed in latest golang version, it's cheaper to avoid the bug.  

Result:

```
DEBUG[12-19|10:13:58.842] Add operation                            module="fhevm:sync compute" op=FHE_TRIVIAL_ENCRYPT handle=29c43b..f40300
DEBUG[12-19|10:13:58.842] Add operation                            module="fhevm:sync compute" op=FHE_TRIVIAL_ENCRYPT handle=59b4f9..500300
DEBUG[12-19|10:13:58.842] Add operation                            module="fhevm:sync compute" op=FHE_MUL             handle=2d8a85..460300
INFO [12-19|10:13:58.842] Sending grpc request                     module="fhevm:sync compute" computations=3 "compressed ciphertexts"=2
```