### PR TITLE
native: reduce FHE storage requirements

### DIFF
--- a/fhevm-engine/fhevm-go-native/fhevm/api.go
+++ b/fhevm-engine/fhevm-go-native/fhevm/api.go
@@ -147,7 +147,13 @@ func (ed ExtraData) String() string {
 }
 
 type ExecutorSession interface {
-	Execute(input []byte, ed ExtraData, output []byte) error
+	/// Add computation to session
+	/// If the operation is not a supported FHE operation, it is discarded.
+	AddComputation(input []byte, ed ExtraData, output []byte) error
+
+	/// Execute added FHE computations and commit result ciphertexts to state
+	Commit(blockNumber int64, storage ChainStorageApi) error
+
 	ContractAddress() common.Address
 	AclContractAddress() common.Address
 	NextSegment() SegmentId
@@ -155,7 +161,7 @@ type ExecutorSession interface {
 	// After commit fhe computations will be put inside the queue
 	// to the blockchain state, also flushes pending computations
 	// from storage to the state
-	Commit(blockNumber int64, storage ChainStorageApi) error
+
 	GetStore() ComputationStore
 }
 
@@ -451,7 +457,7 @@ func (sessionApi *SessionImpl) Commit(blockNumber int64, storage ChainStorageApi
 	return nil
 }
 
-func (sessionApi *SessionImpl) Execute(dataOrig []byte, ed ExtraData, outputOrig []byte) error {
+func (sessionApi *SessionImpl) AddComputation(dataOrig []byte, ed ExtraData, outputOrig []byte) error {
 	log := log(&sessionApi.apiImpl.logger, "session::execute")
 
 	if len(dataOrig) < 4 {

--- a/fhevm-engine/fhevm-go-native/fhevm/hashset.go
+++ b/fhevm-engine/fhevm-go-native/fhevm/hashset.go
@@ -1,0 +1,48 @@
+package fhevm
+
+// OrderedHashSet represents a set that maintains insertion order.
+type OrderedHashSet[T comparable] struct {
+	items map[T]struct{}
+	order []T
+}
+
+// NewOrderedHashSet creates a new OrderedHashSet.
+func NewOrderedHashSet[T comparable]() *OrderedHashSet[T] {
+	return &OrderedHashSet[T]{
+		items: make(map[T]struct{}),
+		order: []T{},
+	}
+}
+
+// Add inserts an item into the set, maintaining insertion order.
+func (s *OrderedHashSet[T]) Add(item T) bool {
+	if _, exists := s.items[item]; !exists {
+		s.items[item] = struct{}{}
+		s.order = append(s.order, item)
+		return true
+	}
+
+	return false
+}
+
+// Contains checks if the item exists in the set.
+func (s *OrderedHashSet[T]) Contains(item T) bool {
+	_, exists := s.items[item]
+	return exists
+}
+
+// Clear removes all elements from the set.
+func (s *OrderedHashSet[T]) Clear() {
+	s.items = make(map[T]struct{})
+	s.order = []T{}
+}
+
+// ToSlice converts the set to a slice of its elements in insertion order.
+func (s *OrderedHashSet[T]) ToSlice() []T {
+	return append([]T{}, s.order...)
+}
+
+// Size returns the number of elements in the set.
+func (s *OrderedHashSet[T]) Size() int {
+	return len(s.items)
+}


### PR DESCRIPTION
fixes #231

- [x] Ensure both SSTOREd and non-SSTOREd handles are properly computed when LateCommit is disabled
- [ ]  Ensure both SSTOREd and non-SSTOREd handles are properly computed when LateCommit is **enabled**