### PR TITLE
feat: delegation and revoke functions and events

### DIFF
--- a/contracts/contracts/ACL.sol
+++ b/contracts/contracts/ACL.sol
@@ -15,10 +15,12 @@ import {tfheExecutorAdd} from "../addresses/TFHEExecutorAddress.sol";
  */
 contract ACL is UUPSUpgradeable, Ownable2StepUpgradeable {
     /// @notice Returned if the delegatee contract is already delegatee for sender & delegator addresses.
-    error AlreadyDelegated();
+    /// @param delegatee   delegatee address.
+    /// @param contractAddress   contract address.
+    error AlreadyDelegated(address delegatee, address contractAddress);
 
     /// @notice Returned if the sender is the delegatee address.
-    error SenderCannotBeContractAddress();
+    error SenderCannotBeContractAddress(address contractAddress);
 
     /// @notice Returned if the contractAddresses array is empty.
     error ContractAddressesIsEmpty();
@@ -30,7 +32,9 @@ contract ACL is UUPSUpgradeable, Ownable2StepUpgradeable {
     error HandlesListIsEmpty();
 
     /// @notice Returned if the the delegatee contract is not already delegatee for sender & delegator addresses.
-    error NotDelegatedYet();
+    /// @param delegatee   delegatee address.
+    /// @param contractAddress   contract address.
+    error NotDelegatedYet(address delegatee, address contractAddress);
 
     /// @notice         Returned if the sender address is not allowed for allow operations.
     /// @param sender   Sender address.
@@ -170,10 +174,10 @@ contract ACL is UUPSUpgradeable, Ownable2StepUpgradeable {
         ACLStorage storage $ = _getACLStorage();
         for (uint256 k = 0; k < lenghtContractAddresses; k++) {
             if (contractAddresses[k] == msg.sender) {
-                revert SenderCannotBeContractAddress();
+                revert SenderCannotBeContractAddress(contractAddresses[k]);
             }
             if ($.delegates[msg.sender][delegatee][contractAddresses[k]]) {
-                revert AlreadyDelegated();
+                revert AlreadyDelegated(delegatee, contractAddresses[k]);
             }
             $.delegates[msg.sender][delegatee][contractAddresses[k]] = true;
         }
@@ -197,7 +201,7 @@ contract ACL is UUPSUpgradeable, Ownable2StepUpgradeable {
 
         for (uint256 k = 0; k < lenghtContractAddresses; k++) {
             if ($.delegates[msg.sender][delegatee][contractAddresses[k]]) {
-                revert NotDelegatedYet();
+                revert NotDelegatedYet(delegatee, contractAddresses[k]);
             }
             $.delegates[msg.sender][delegatee][contractAddresses[k]] = false;
         }

--- a/contracts/test/acl/acl.t.sol
+++ b/contracts/test/acl/acl.t.sol
@@ -108,8 +108,11 @@ contract ACLTest is Test {
 
         vm.prank(sender);
         vm.expectEmit(address(acl));
-        emit ACL.NewDelegation(sender, delegatee, delegateeContract);
-        acl.delegateAccount(delegatee, delegateeContract);
+
+        address[] memory contractAddresses = new address[](1);
+        contractAddresses[0] = delegateeContract;
+        emit ACL.NewDelegation(sender, delegatee, contractAddresses);
+        acl.delegateAccount(delegatee, contractAddresses);
         vm.assertFalse(acl.allowedOnBehalf(delegatee, handle, delegateeContract, sender));
 
         /// @dev The sender and the delegatee contract must be allowed to use the handle before it delegates.
@@ -135,13 +138,17 @@ contract ACLTest is Test {
 
         vm.prank(sender);
         vm.expectRevert(ACL.AlreadyDelegated.selector);
-        acl.delegateAccount(delegatee, delegateeContract);
+        address[] memory contractAddresses = new address[](1);
+        contractAddresses[0] = delegateeContract;
+        acl.delegateAccount(delegatee, contractAddresses);
     }
 
     function test_CannotDelegateIfSenderIsDelegateeContract(address sender, address delegatee) public {
         vm.prank(sender);
-        vm.expectRevert(ACL.SenderCannotBeDelegateeAddress.selector);
-        acl.delegateAccount(delegatee, sender);
+        vm.expectRevert(ACL.SenderCannotBeContractAddress.selector);
+        address[] memory contractAddresses = new address[](1);
+        contractAddresses[0] = sender;
+        acl.delegateAccount(delegatee, contractAddresses);
     }
 
     function test_CanDelegateAccountIfAccountNotAllowed(
@@ -156,17 +163,18 @@ contract ACLTest is Test {
 
         vm.prank(sender);
         vm.expectEmit(address(acl));
-        emit ACL.NewDelegation(sender, delegatee, delegateeContract);
-        acl.delegateAccount(delegatee, delegateeContract);
+        address[] memory contractAddresses = new address[](1);
+        contractAddresses[0] = delegateeContract;
+        emit ACL.NewDelegation(sender, delegatee, contractAddresses);
+        acl.delegateAccount(delegatee, contractAddresses);
 
         vm.assertFalse(acl.allowedOnBehalf(delegatee, handle, delegateeContract, sender));
     }
 
-    function test_AnyoneCanAllowForDecryptionIfEmptyList(address sender) public {
+    function test_NoOneCanAllowForDecryptionIfEmptyList(address sender) public {
         uint256[] memory handlesList = new uint256[](0);
         vm.prank(sender);
-        vm.expectEmit(address(acl));
-        emit ACL.AllowedForDecryption(address(sender), handlesList);
+        vm.expectRevert(ACL.HandlesListIsEmpty.selector);
         acl.allowForDecryption(handlesList);
     }
 

--- a/contracts/test/acl/acl.t.sol
+++ b/contracts/test/acl/acl.t.sol
@@ -137,7 +137,7 @@ contract ACLTest is Test {
         );
 
         vm.prank(sender);
-        vm.expectRevert(ACL.AlreadyDelegated.selector);
+        vm.expectPartialRevert(ACL.AlreadyDelegated.selector);
         address[] memory contractAddresses = new address[](1);
         contractAddresses[0] = delegateeContract;
         acl.delegateAccount(delegatee, contractAddresses);
@@ -145,7 +145,7 @@ contract ACLTest is Test {
 
     function test_CannotDelegateIfSenderIsDelegateeContract(address sender, address delegatee) public {
         vm.prank(sender);
-        vm.expectRevert(ACL.SenderCannotBeContractAddress.selector);
+        vm.expectPartialRevert(ACL.SenderCannotBeContractAddress.selector);
         address[] memory contractAddresses = new address[](1);
         contractAddresses[0] = sender;
         acl.delegateAccount(delegatee, contractAddresses);


### PR DESCRIPTION
This PR adds  the possibility to delegate and revoke ACL authorization, as per issue #265 we can add delegation for a list of contract addresses of length of up to 10.
Note: this PR also now forbids the possibility to call `allowForDecryption` with an empty list.