### PR TITLE
chore: bump alloy version

### DIFF
--- a/fhevm-engine/listener/Cargo.toml
+++ b/fhevm-engine/listener/Cargo.toml
@@ -11,11 +11,11 @@ bench = false
 
 [dependencies]
 # workspace dependencies
-alloy = { version = "=0.9.2", features = ["contract", "json", "providers", "provider-ws", "pubsub", "rpc-types", "sol-types"] }
-alloy-rpc-types = "=0.9.2"
-alloy-sol-types = "=0.8.19"
-alloy-primitives = "=0.8.19"
-alloy-provider = "=0.9.2"
+alloy = { version = "0.9", features = ["contract", "json", "providers", "provider-ws", "pubsub", "rpc-types", "sol-types"] }
+alloy-rpc-types = "0.11"
+alloy-sol-types = "0.8"
+alloy-primitives = "0.8"
+alloy-provider = "0.11"
 clap = { workspace = true }
 futures-util = "=0.3"
 serde = { workspace = true }

--- a/fhevm-engine/listener/src/bin/main.rs
+++ b/fhevm-engine/listener/src/bin/main.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use alloy::primitives::Address;
 use alloy::providers::{Provider, ProviderBuilder, RootProvider, WsConnect};
 use alloy::pubsub::{PubSubFrontend, SubscriptionStream};
-use alloy::rpc::types::{BlockNumberOrTag, Filter};
-use alloy_rpc_types::Log;
+use alloy::rpc::types::{BlockNumberOrTag, Filter, Log};
+
 use alloy_sol_types::SolEventInterface;
 
 use clap::Parser;


### PR DESCRIPTION
Resolve error:

```
fhevm-engine$ cargo build --release
 Compiling alloy-json-rpc v0.3.6
   Compiling alloy-rpc-types-eth v0.3.6
error[E0277]: the trait bound `winnow::stream::stateful::Stateful<&'i str, RecursionCheck>: StreamIsPartial` is not satisfied because the trait comes from a different crate version
    --> /home/tech/.cargo/registry/src/index.crates.io-6f17d22bba15001f/alloy-dyn-abi-0.8.19/src/coerce.rs:169:17
     |
169  |                 take_while(min.., move |c: char| !unsafe { chs.get_unchecked(..l) }.contains(&c))
```