### PR TITLE
feat: first version of input proofs in gw-listener

### DIFF
--- a/fhevm-engine/Cargo.lock
+++ b/fhevm-engine/Cargo.lock
@@ -2961,6 +2961,7 @@ dependencies = [
  "anyhow",
  "clap",
  "foundry-compilers",
+ "futures-util",
  "serial_test",
  "sqlx",
  "tokio",

--- a/fhevm-engine/fhevm-db/migrations/20250221112128_gw_listener_last_block.sql
+++ b/fhevm-engine/fhevm-db/migrations/20250221112128_gw_listener_last_block.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS gw_listener_last_block (
+    -- Used to make sure we only have one record in the table, the one with dummy_id = true.
+    dummy_id BOOLEAN PRIMARY KEY DEFAULT true,
+
+    -- NULL means subscription will starte from the "latest" block.
+    last_block_num BIGINT CHECK (last_block_num >= 0)
+)

--- a/fhevm-engine/gw-listener/.sqlx/query-4348b12a11ea6fcb102d97b1979b63ac167f55188496f006abce0ee1159b6663.json
+++ b/fhevm-engine/gw-listener/.sqlx/query-4348b12a11ea6fcb102d97b1979b63ac167f55188496f006abce0ee1159b6663.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT into gw_listener_last_block (dummy_id, last_block_num)\n            VALUES (true, $1)\n            ON CONFLICT (dummy_id) DO UPDATE SET last_block_num = EXCLUDED.last_block_num",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4348b12a11ea6fcb102d97b1979b63ac167f55188496f006abce0ee1159b6663"
+}

--- a/fhevm-engine/gw-listener/.sqlx/query-5d0594aefc96b09bbfc06cc5bfee7a066b01630afec98b2a8407e05fb79466b6.json
+++ b/fhevm-engine/gw-listener/.sqlx/query-5d0594aefc96b09bbfc06cc5bfee7a066b01630afec98b2a8407e05fb79466b6.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT last_block_num\n            FROM gw_listener_last_block\n            WHERE dummy_id = true",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "last_block_num",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "5d0594aefc96b09bbfc06cc5bfee7a066b01630afec98b2a8407e05fb79466b6"
+}

--- a/fhevm-engine/gw-listener/.sqlx/query-74b048fe6f93de73a64257cd1f4804e7f83041922df6494ebaaa754630bd8d2d.json
+++ b/fhevm-engine/gw-listener/.sqlx/query-74b048fe6f93de73a64257cd1f4804e7f83041922df6494ebaaa754630bd8d2d.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH ins AS (\n                            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, input)\n                            VALUES ($1, $2, $3, $4, $5)\n                            ON CONFLICT(zk_proof_id) DO NOTHING\n                        )\n                        SELECT pg_notify($6, '')",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_notify",
+        "type_info": "Void"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int4",
+        "Text",
+        "Text",
+        "Bytea",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "74b048fe6f93de73a64257cd1f4804e7f83041922df6494ebaaa754630bd8d2d"
+}

--- a/fhevm-engine/gw-listener/Cargo.toml
+++ b/fhevm-engine/gw-listener/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 alloy = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
+futures-util = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/fhevm-engine/gw-listener/src/bin/gw_listener.rs
+++ b/fhevm-engine/gw-listener/src/bin/gw_listener.rs
@@ -10,6 +10,9 @@ struct Conf {
     #[arg(long, default_value = "16")]
     database_pool_size: u32,
 
+    #[arg(long, default_value = "verify_proof_requests")]
+    verify_proof_req_database_channel: String,
+
     #[arg(long)]
     gw_url: Url,
 

--- a/fhevm-engine/gw-listener/src/gw_listener.rs
+++ b/fhevm-engine/gw-listener/src/gw_listener.rs
@@ -1,0 +1,194 @@
+use std::time::Duration;
+
+use alloy::{
+    eips::BlockNumberOrTag, network::Ethereum, primitives::Address, providers::Provider, sol,
+};
+use futures_util::StreamExt;
+use sqlx::{postgres::PgPoolOptions, Pool, Postgres};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
+
+use crate::ConfigSettings;
+
+const LOG_TARGET: &str = "gw_listener";
+
+sol!(
+    #[sol(rpc)]
+    ZKPoKManager,
+    "artifacts/ZKPoKManager.sol/ZKPoKManager.json"
+);
+
+pub struct GatewayListener<P: Provider<Ethereum> + Clone + 'static> {
+    zkpok_manager_address: Address,
+    conf: ConfigSettings,
+    cancel_token: CancellationToken,
+    provider: P,
+}
+
+impl<P: Provider<Ethereum> + Clone + 'static> GatewayListener<P> {
+    pub fn new(
+        zkpok_manager_address: Address,
+        conf: ConfigSettings,
+        cancel_token: CancellationToken,
+        provider: P,
+    ) -> Self {
+        GatewayListener {
+            zkpok_manager_address,
+            conf,
+            cancel_token,
+            provider,
+        }
+    }
+
+    pub async fn run(&self) -> anyhow::Result<()> {
+        info!(target: LOG_TARGET, "Starting Gateway Listener with: {:?}, ZKPoKManager: {}", self.conf, self.zkpok_manager_address);
+        let db_pool = PgPoolOptions::new()
+            .max_connections(self.conf.database_pool_size)
+            .connect(&self.conf.database_url)
+            .await?;
+
+        let mut sleep_duration = self.conf.error_sleep_initial_secs as u64;
+        loop {
+            if self.cancel_token.is_cancelled() {
+                info!(target: LOG_TARGET, "Stopping");
+                break;
+            }
+
+            match self.run_loop(&db_pool, &mut sleep_duration).await {
+                Ok(_) => {}
+                Err(e) => {
+                    error!(target: LOG_TARGET, "Encountered an error: {:?}, retrying in {} seconds", e, sleep_duration);
+                    self.sleep_with_backoff(&mut sleep_duration).await;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn run_loop(
+        &self,
+        db_pool: &Pool<Postgres>,
+        sleep_duration: &mut u64,
+    ) -> anyhow::Result<()> {
+        let zkpok_manager = ZKPoKManager::new(self.zkpok_manager_address, &self.provider);
+        let mut from_block = self.get_last_block_num(db_pool).await?;
+        let filter = zkpok_manager
+            .VerifyProofRequest_filter()
+            .from_block(from_block)
+            .subscribe()
+            .await?;
+        let mut stream = filter.into_stream().fuse();
+        loop {
+            tokio::select! {
+                _ = self.cancel_token.cancelled() => {
+                    break;
+                }
+                item = stream.next() => {
+                    if item.is_none() {
+                        error!(target: LOG_TARGET, "Received None item from event stream");
+                        continue;
+                    }
+                    let (request, log) = item.unwrap()?;
+                    info!(target: LOG_TARGET, "Received event for ZK proof request ID: {}", request.zkProofId);
+                    match log.block_number {
+                        Some(event_block_num) => {
+                            match from_block {
+                                BlockNumberOrTag::Latest => {
+                                    info!(target: LOG_TARGET, "Updating from block from latest to {}", event_block_num);
+                                    from_block = BlockNumberOrTag::Number(event_block_num);
+                                    self.update_last_block_num(db_pool, Some(event_block_num)).await?;
+                                }
+                                BlockNumberOrTag::Number(from_block_num) => {
+                                    if from_block_num < event_block_num {
+                                        info!(target: LOG_TARGET, "Updating from block from {} to {}", from_block_num, event_block_num);
+                                        from_block = BlockNumberOrTag::Number(event_block_num);
+                                        self.update_last_block_num(db_pool, Some(event_block_num)).await?;
+                                    }
+                                }
+                                _ => unreachable!("Unexpected from block type"),
+                            }
+                        }
+                        None => {
+                            error!(target: LOG_TARGET, "Received an event without a block number, updating from block to latest");
+                            from_block = BlockNumberOrTag::Latest;
+                            self.update_last_block_num(db_pool, None).await?;
+                        }
+                    }
+
+                    // TODO: check if we can avoid the cast from u256 to i64
+                    sqlx::query!(
+                        "WITH ins AS (
+                            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, input)
+                            VALUES ($1, $2, $3, $4, $5)
+                            ON CONFLICT(zk_proof_id) DO NOTHING
+                        )
+                        SELECT pg_notify($6, '')",
+                        request.zkProofId.to::<i64>(),
+                        request.contractChainId.to::<i32>(),
+                        request.contractAddress.to_string(),
+                        request.userAddress.to_string(),
+                        Some(request.ciphertextWithZKProof.as_ref()),
+                        self.conf.verify_proof_req_db_channel
+                    )
+                    .execute(db_pool)
+                    .await?;
+                }
+            }
+            // Reset sleep duration on successful iteration.
+            self.reset_sleep_duration(sleep_duration);
+        }
+        Ok(())
+    }
+
+    fn reset_sleep_duration(&self, sleep_duration: &mut u64) {
+        *sleep_duration = self.conf.error_sleep_initial_secs as u64;
+    }
+
+    async fn sleep_with_backoff(&self, sleep_duration: &mut u64) {
+        tokio::time::sleep(Duration::from_secs(*sleep_duration)).await;
+        *sleep_duration = std::cmp::min(*sleep_duration * 2, self.conf.error_sleep_max_secs as u64);
+    }
+
+    async fn get_last_block_num(
+        &self,
+        db_pool: &Pool<Postgres>,
+    ) -> anyhow::Result<BlockNumberOrTag> {
+        let rows = sqlx::query!(
+            "SELECT last_block_num
+            FROM gw_listener_last_block
+            WHERE dummy_id = true"
+        )
+        .fetch_all(db_pool)
+        .await?;
+        assert!(
+            rows.len() <= 1,
+            "Expected at most one row in gw_listener_last_block, found {}",
+            rows.len()
+        );
+
+        Ok(rows.first().map_or(BlockNumberOrTag::Latest, |row| {
+            if let Some(n) = row.last_block_num {
+                BlockNumberOrTag::Number(n.try_into().expect("Got an invalid block number"))
+            } else {
+                BlockNumberOrTag::Latest
+            }
+        }))
+    }
+
+    async fn update_last_block_num(
+        &self,
+        db_pool: &Pool<Postgres>,
+        block_num: Option<u64>,
+    ) -> anyhow::Result<()> {
+        info!(target: LOG_TARGET, "Updating last block number to: {:?}", block_num);
+        sqlx::query!(
+            "INSERT into gw_listener_last_block (dummy_id, last_block_num)
+            VALUES (true, $1)
+            ON CONFLICT (dummy_id) DO UPDATE SET last_block_num = EXCLUDED.last_block_num",
+            block_num.map::<i64, _>(|n| n.try_into().expect("Invalid block number for update"))
+        )
+        .execute(db_pool)
+        .await?;
+        Ok(())
+    }
+}

--- a/fhevm-engine/gw-listener/src/lib.rs
+++ b/fhevm-engine/gw-listener/src/lib.rs
@@ -1,1 +1,29 @@
+use alloy::transports::http::reqwest::Url;
 
+pub mod gw_listener;
+
+#[derive(Clone, Debug)]
+pub struct ConfigSettings {
+    pub database_url: String,
+    pub database_pool_size: u32,
+    pub verify_proof_req_db_channel: String,
+
+    pub gw_url: Url,
+
+    pub error_sleep_initial_secs: u16,
+    pub error_sleep_max_secs: u16,
+}
+
+impl Default for ConfigSettings {
+    fn default() -> Self {
+        Self {
+            database_url: std::env::var("DATABASE_URL")
+                .unwrap_or("postgres://postgres:postgres@localhost/coprocessor".to_owned()),
+            database_pool_size: 16,
+            verify_proof_req_db_channel: "verify_proof_requests".to_owned(),
+            gw_url: "ws://127.0.0.1:8546".try_into().expect("Invalid URL"),
+            error_sleep_initial_secs: 1,
+            error_sleep_max_secs: 10,
+        }
+    }
+}

--- a/fhevm-engine/gw-listener/tests/gw_listener_tests.rs
+++ b/fhevm-engine/gw-listener/tests/gw_listener_tests.rs
@@ -1,0 +1,124 @@
+use std::time::Duration;
+
+use alloy::{
+    network::EthereumWallet,
+    node_bindings::{Anvil, AnvilInstance},
+    primitives::U256,
+    providers::{Provider, ProviderBuilder, WsConnect},
+    signers::local::PrivateKeySigner,
+    sol,
+};
+use gw_listener::{gw_listener::GatewayListener, ConfigSettings};
+use serial_test::serial;
+use sqlx::{postgres::PgPoolOptions, Pool, Postgres};
+use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
+use tracing::Level;
+
+sol!(
+    #[sol(rpc)]
+    ZKPoKManager,
+    "artifacts/ZKPoKManager.sol/ZKPoKManager.json"
+);
+
+struct TestEnvironment {
+    wallet: EthereumWallet,
+    conf: ConfigSettings,
+    cancel_token: CancellationToken,
+    db_pool: Pool<Postgres>,
+    anvil: AnvilInstance,
+}
+
+impl TestEnvironment {
+    async fn new() -> anyhow::Result<Self> {
+        let _ = tracing_subscriber::fmt()
+            .json()
+            .with_level(true)
+            .with_max_level(Level::DEBUG)
+            .with_test_writer()
+            .try_init();
+
+        let conf = ConfigSettings::default();
+
+        let db_pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&conf.database_url)
+            .await?;
+
+        // Delete all proofs from the database.
+        sqlx::query!("TRUNCATE verify_proofs",)
+            .execute(&db_pool)
+            .await?;
+
+        // Delete last block.
+        sqlx::query!("TRUNCATE gw_listener_last_block",)
+            .execute(&db_pool)
+            .await?;
+
+        let anvil = Anvil::new().block_time(1).try_spawn()?;
+        let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
+        let wallet = signer.clone().into();
+        Ok(Self {
+            wallet,
+            conf,
+            cancel_token: CancellationToken::new(),
+            db_pool,
+            anvil,
+        })
+    }
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn verify_proof_request_inserted_into_db() -> anyhow::Result<()> {
+    let env = TestEnvironment::new().await?;
+    let provider = ProviderBuilder::new()
+        .wallet(env.wallet)
+        .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
+        .await?;
+    let zkpok_manager = ZKPoKManager::deploy(&provider).await?;
+    let gw_listener = GatewayListener::new(
+        *zkpok_manager.address(),
+        env.conf.clone(),
+        env.cancel_token.clone(),
+        provider.clone(),
+    );
+
+    let run_handle = tokio::spawn(async move { gw_listener.run().await });
+
+    let contract_address = PrivateKeySigner::random().address();
+    let user_address = PrivateKeySigner::random().address();
+    let txn_req = zkpok_manager
+        .verifyProofRequest(
+            U256::from(42),
+            contract_address,
+            user_address,
+            (&[1u8; 2048]).into(),
+        )
+        .into_transaction_request();
+    let pending_txn = provider.send_transaction(txn_req).await?;
+    let receipt = pending_txn.get_receipt().await?;
+    assert!(receipt.status());
+
+    loop {
+        let rows = sqlx::query!(
+            "SELECT zk_proof_id, chain_id, contract_address, user_address, input
+             FROM verify_proofs",
+        )
+        .fetch_all(&env.db_pool)
+        .await?;
+        if rows.len() > 0 {
+            let row = &rows[0];
+            assert_eq!(row.chain_id, 42);
+            assert_eq!(row.contract_address, contract_address.to_string());
+            assert_eq!(row.user_address, user_address.to_string());
+            assert_eq!(row.input, Some([1u8; 2048].to_vec()));
+            break;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    env.cancel_token.cancel();
+    run_handle.await??;
+    Ok(())
+}

--- a/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::str::FromStr;
 
 use alloy::{
     network::EthereumWallet, primitives::Address, providers::ProviderBuilder,
@@ -74,25 +74,23 @@ async fn main() -> anyhow::Result<()> {
     let conf = Conf::parse();
     let signer = PrivateKeySigner::from_str(conf.private_key.trim())?;
     let wallet = EthereumWallet::new(signer.clone());
-    let provider = Arc::new(
-        ProviderBuilder::new()
-            .wallet(wallet.clone())
-            .on_http(conf.gateway_url.clone()),
-    );
+    let provider = ProviderBuilder::new()
+        .wallet(wallet.clone())
+        .on_http(conf.gateway_url.clone());
     let database_url = conf
         .database_url
         .clone()
         .unwrap_or_else(|| std::env::var("DATABASE_URL").expect("DATABASE_URL is undefined"));
     let cancel_token = CancellationToken::new();
     let sender = TransactionSender::new(
-        &conf.zkpok_manager_address,
-        &conf.ciphertext_storage_address,
+        conf.zkpok_manager_address,
+        conf.ciphertext_storage_address,
         signer,
         provider,
         cancel_token.clone(),
         ConfigSettings {
-            db_url: database_url,
-            db_pool_size: conf.database_pool_size,
+            database_url,
+            database_pool_size: conf.database_pool_size,
 
             verify_proof_resp_db_channel: conf.verify_proof_resp_database_channel,
             add_ciphertexts_db_channel: conf.add_ciphertexts_database_channel,

--- a/fhevm-engine/transaction-sender/src/lib.rs
+++ b/fhevm-engine/transaction-sender/src/lib.rs
@@ -3,8 +3,8 @@ mod transaction_sender;
 
 #[derive(Clone, Debug)]
 pub struct ConfigSettings {
-    pub db_url: String,
-    pub db_pool_size: u32,
+    pub database_url: String,
+    pub database_pool_size: u32,
 
     pub verify_proof_resp_db_channel: String,
     pub add_ciphertexts_db_channel: String,
@@ -22,9 +22,10 @@ pub struct ConfigSettings {
 impl Default for ConfigSettings {
     fn default() -> Self {
         Self {
-            db_url: std::env::var("DATABASE_URL").expect("DATABASE_URL is undefined"),
-            db_pool_size: 10,
-            verify_proof_resp_db_channel: "verify_proofs".to_owned(),
+            database_url: std::env::var("DATABASE_URL")
+                .unwrap_or("postgres://postgres:postgres@localhost/coprocessor".to_owned()),
+            database_pool_size: 10,
+            verify_proof_resp_db_channel: "verify_proof_responses".to_owned(),
             add_ciphertexts_db_channel: "add_ciphertexts".to_owned(),
             verify_proof_resp_batch_limit: 128,
             verify_proof_resp_max_retries: 15,

--- a/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -2,7 +2,6 @@ use super::TransactionOperation;
 use alloy::{network::Ethereum, primitives::Address, providers::Provider, sol};
 use async_trait::async_trait;
 use sqlx::{Pool, Postgres};
-use std::sync::Arc;
 
 sol!(
     #[sol(rpc)]
@@ -13,11 +12,11 @@ sol!(
 #[derive(Clone)]
 pub struct AddCiphertextOperation<P: Provider<Ethereum> + Clone + 'static> {
     ciphertext_storage_address: Address,
-    provider: Arc<P>,
+    provider: P,
 }
 
 impl<P: Provider<Ethereum> + Clone + 'static> AddCiphertextOperation<P> {
-    pub fn new(ciphertext_storage_address: Address, provider: Arc<P>) -> Self {
+    pub fn new(ciphertext_storage_address: Address, provider: P) -> Self {
         Self {
             ciphertext_storage_address,
             provider,

--- a/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
+++ b/fhevm-engine/transaction-sender/src/ops/verify_proof.rs
@@ -33,7 +33,7 @@ sol!(
 #[derive(Clone)]
 pub(crate) struct VerifyProofOperation<P: Provider<Ethereum> + Clone + 'static> {
     zkpok_manager_address: Address,
-    provider: std::sync::Arc<P>,
+    provider: P,
     signer: PrivateKeySigner,
     database_conf: crate::ConfigSettings,
     gas: Option<u64>,
@@ -42,7 +42,7 @@ pub(crate) struct VerifyProofOperation<P: Provider<Ethereum> + Clone + 'static> 
 impl<P: alloy::providers::Provider<Ethereum> + Clone + 'static> VerifyProofOperation<P> {
     pub(crate) fn new(
         zkpok_manager_address: Address,
-        provider: std::sync::Arc<P>,
+        provider: P,
         signer: PrivateKeySigner,
         database_conf: crate::ConfigSettings,
         gas: Option<u64>,
@@ -111,7 +111,7 @@ impl<P: alloy::providers::Provider<Ethereum> + Clone + 'static> VerifyProofOpera
     async fn process_proof(
         &self,
         db_pool: Pool<Postgres>,
-        provider: std::sync::Arc<P>,
+        provider: P,
         txn_request: (i64, impl Into<TransactionRequest>),
     ) -> anyhow::Result<()> {
         info!(target: VERIFY_PROOFS_TARGET, "Processing proof with proof id {}", txn_request.0);

--- a/fhevm-engine/transaction-sender/tests/common.rs
+++ b/fhevm-engine/transaction-sender/tests/common.rs
@@ -1,4 +1,4 @@
-use alloy::{signers::local::PrivateKeySigner, sol};
+use alloy::{primitives::Address, signers::local::PrivateKeySigner, sol};
 use sqlx::{postgres::PgPoolOptions, Pool, Postgres};
 use tokio_util::sync::CancellationToken;
 use tracing::Level;
@@ -21,6 +21,8 @@ pub struct TestEnvironment {
     pub conf: ConfigSettings,
     pub cancel_token: CancellationToken,
     pub db_pool: Pool<Postgres>,
+    pub contract_address: Address,
+    pub user_address: Address,
 }
 
 impl TestEnvironment {
@@ -36,7 +38,7 @@ impl TestEnvironment {
 
         let db_pool = PgPoolOptions::new()
             .max_connections(1)
-            .connect(&conf.db_url)
+            .connect(&conf.database_url)
             .await?;
 
         // Delete all proofs from the database.
@@ -49,6 +51,8 @@ impl TestEnvironment {
             conf: conf,
             cancel_token: CancellationToken::new(),
             db_pool,
+            contract_address: PrivateKeySigner::random().address(),
+            user_address: PrivateKeySigner::random().address(),
         })
     }
 }


### PR DESCRIPTION
This commit adds input poofs handling in the gw-listener. It supports restarting from the last seen block in case of a crash or stop of the service.

We assume that the ZKPoKManager can handle proof requests that were already completed, meaning that redoing some requests won't have negative effects. That allows us to only remember the last **seen** block number. For more information on the ZKPoKManager, see:

```@dev This means a "late" response will not be reverted, just ignored```

https://github.com/zama-ai/gateway-l2/blob/main/contracts/ZKPoKManager.sol#L125

Error handling will be improved in future commits. More tests will be
added too.

Reorg handling is also a topic for a future commit.