### PR TITLE
fix: EIP712 verify proof signature

### DIFF
--- a/fhevm-engine/Cargo.lock
+++ b/fhevm-engine/Cargo.lock
@@ -2550,14 +2550,17 @@ dependencies = [
  "bigdecimal",
  "bincode",
  "hex",
+ "lru 0.12.5",
  "paste",
  "prost",
  "rand 0.9.0",
  "rand_chacha 0.3.1",
  "serde",
  "sha3",
+ "sqlx",
  "strum",
  "tfhe",
+ "tokio",
  "tonic",
  "tonic-build",
 ]
@@ -7428,8 +7431,22 @@ dependencies = [
 name = "zkproof-worker"
 version = "0.6.1"
 dependencies = [
+ "alloy-primitives",
+ "anyhow",
+ "bincode",
  "clap",
+ "fhevm-engine-common",
+ "lru 0.12.5",
+ "rand 0.9.0",
+ "sha3",
+ "sqlx",
+ "test-harness",
  "tfhe",
+ "thiserror 2.0.11",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
+++ b/fhevm-engine/transaction-sender/src/bin/transaction_sender.rs
@@ -105,7 +105,8 @@ async fn main() -> anyhow::Result<()> {
             error_sleep_max_secs: conf.error_sleep_max_secs,
         },
         None,
-    );
+    )
+    .await?;
     install_signal_handlers(cancel_token)?;
     sender.run().await
 }

--- a/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
+++ b/fhevm-engine/transaction-sender/src/ops/add_ciphertext.rs
@@ -13,13 +13,19 @@ sol!(
 pub struct AddCiphertextOperation<P: Provider<Ethereum> + Clone + 'static> {
     ciphertext_storage_address: Address,
     provider: P,
+    conf: crate::ConfigSettings,
 }
 
 impl<P: Provider<Ethereum> + Clone + 'static> AddCiphertextOperation<P> {
-    pub fn new(ciphertext_storage_address: Address, provider: P) -> Self {
+    pub fn new(
+        ciphertext_storage_address: Address,
+        provider: P,
+        conf: crate::ConfigSettings,
+    ) -> Self {
         Self {
             ciphertext_storage_address,
             provider,
+            conf,
         }
     }
 }
@@ -30,7 +36,7 @@ where
     P: alloy::providers::Provider<Ethereum> + Clone + 'static,
 {
     fn channel(&self) -> &str {
-        "add_ciphertexts"
+        &self.conf.add_ciphertexts_db_channel
     }
 
     async fn execute(&self, _db_pool: &Pool<Postgres>) -> anyhow::Result<bool> {


### PR DESCRIPTION
* data structure name of `EIP712ZKPoK`
* `contractChainId` instead of `chainId` in EIP712ZKPoK
* use the GW chain ID in the EIP712 domain

Honour the `verify_proof_resp_database_channel` and the `add_ciphertexts_database_channel` config options.