### PR TITLE
fix(gw-listener): reconnect on event stream close

### DIFF
--- a/fhevm-engine/gw-listener/src/gw_listener.rs
+++ b/fhevm-engine/gw-listener/src/gw_listener.rs
@@ -77,6 +77,7 @@ impl<P: Provider<Ethereum> + Clone + 'static> GatewayListener<P> {
             .from_block(from_block)
             .subscribe()
             .await?;
+        info!(target: LOG_TARGET, "Subscribed to ZKPoKManager.VerifyProofRequest events");
         let mut stream = filter.into_stream().fuse();
         loop {
             tokio::select! {
@@ -85,8 +86,8 @@ impl<P: Provider<Ethereum> + Clone + 'static> GatewayListener<P> {
                 }
                 item = stream.next() => {
                     if item.is_none() {
-                        error!(target: LOG_TARGET, "Received None item from event stream");
-                        continue;
+                        error!(target: LOG_TARGET, "Event stream closed");
+                        return Err(anyhow::anyhow!("Event stream closed"))
                     }
                     let (request, log) = item.unwrap()?;
                     info!(target: LOG_TARGET, "Received event for ZK proof request ID: {}", request.zkProofId);

--- a/fhevm-engine/transaction-sender/src/transaction_sender.rs
+++ b/fhevm-engine/transaction-sender/src/transaction_sender.rs
@@ -101,14 +101,14 @@ impl<P: Provider<Ethereum> + Clone + 'static> TransactionSender<P> {
                                 // Maybe no more work to do, go and wait for the next notification.
                                 sender.reset_sleep_duration(&mut sleep_duration);
 
-                                let listener = listener.try_recv().fuse();
+                                let notification = listener.try_recv().fuse();
                                 tokio::select! {
                                     _ = token.cancelled() => {
                                         info!(target: TXN_SENDER_TARGET, "Operation {} stopping", op_channel);
                                         break;
                                     }
-                                    notif = listener => {
-                                        match notif {
+                                    n = notification => {
+                                        match n {
                                             Ok(Some(_)) => {
                                                 debug!(target: TXN_SENDER_TARGET,
                                                     "Operation {} received notification, rechecking for work", op_channel);


### PR DESCRIPTION
If the event stream returns None, consider the stream closed and resubscribe to the event stream.