### PR TITLE
 Use tenant-api-key in SnS worker

### DIFF
--- a/fhevm-engine/fhevm-keys/sns_pk
+++ b/fhevm-engine/fhevm-keys/sns_pk
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:574b842203629aab9ecd281bad979a59761d47540c9f3d4b052ee0a5b77f32eb
-size 857505920
+oid sha256:26e35fe092c6dcf7f0d62d8832b76d8dcce7d88102b5c64c39137fcf4c67007e
+size 872415360

--- a/fhevm-engine/fhevm-keys/sns_sk
+++ b/fhevm-engine/fhevm-keys/sns_sk
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:02763e5f2e3bdd3e6726043e1f1280c97340c9846d0822c3cba9221b3078e66b
-size 65676
+oid sha256:cb53bc8bd6aaa8781fd28cede2a749dc2d883bcbcfdae1de0011c19c3a445feb
+size 65709

--- a/fhevm-engine/sns-executor/README.md
+++ b/fhevm-engine/sns-executor/README.md
@@ -37,7 +37,7 @@ WHERE tenant_id = 1;
 # Run a single instance of the worker
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/coprocessor \
 cargo run --release -- \
---tenant-id 1 \
+--tenant-api-key "a1503fb6-d79b-4e9e-826d-44cf262f3e05" \
 --pg-listen-channel "event_pbs_new_work" \
 --pg-notify-channel "event_pbs_computed" \
 ```

--- a/fhevm-engine/sns-executor/src/bin/sns_worker.rs
+++ b/fhevm-engine/sns-executor/src/bin/sns_worker.rs
@@ -36,7 +36,7 @@ async fn main() {
     tracing_subscriber::fmt().json().with_level(true).init();
 
     let conf = sns_executor::Config {
-        tenant_id: args.tenant_id as i32,
+        tenant_api_key: args.tenant_api_key,
         db: DBConfig {
             url: db_url,
             listen_channel: args.pg_listen_channel,

--- a/fhevm-engine/sns-executor/src/bin/utils/daemon_cli.rs
+++ b/fhevm-engine/sns-executor/src/bin/utils/daemon_cli.rs
@@ -3,9 +3,9 @@ use clap::{command, Parser};
 #[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
 pub struct Args {
-    /// Tenant ID
-    #[arg(long, default_value_t = 4)]
-    pub tenant_id: u32,
+    /// Tenant API key
+    #[arg(long)]
+    pub tenant_api_key: String,
 
     /// Work items batch size
     #[arg(long, default_value_t = 4)]

--- a/fhevm-engine/sns-executor/src/executor.rs
+++ b/fhevm-engine/sns-executor/src/executor.rs
@@ -32,7 +32,7 @@ pub(crate) async fn run_loop(
     conf: &Config,
     mut cancel_chan: broadcast::Receiver<()>,
 ) -> Result<(), ExecutionError> {
-    let tenant_id = conf.tenant_id;
+    let tenant_api_key = &conf.tenant_api_key;
     let conf = &conf.db;
 
     let pool = sqlx::postgres::PgPoolOptions::new()
@@ -46,7 +46,7 @@ pub(crate) async fn run_loop(
 
     let keys: KeySet = match keys {
         Some(keys) => keys,
-        None => fetch_keyset(&pool, tenant_id).await?,
+        None => fetch_keyset(&pool, tenant_api_key).await?,
     };
 
     loop {

--- a/fhevm-engine/sns-executor/src/lib.rs
+++ b/fhevm-engine/sns-executor/src/lib.rs
@@ -29,7 +29,7 @@ pub struct DBConfig {
 }
 
 pub struct Config {
-    pub tenant_id: i32,
+    pub tenant_api_key: String,
     pub db: DBConfig,
 }
 

--- a/fhevm-engine/sns-executor/src/tests/mod.rs
+++ b/fhevm-engine/sns-executor/src/tests/mod.rs
@@ -158,11 +158,12 @@ fn read_test_file(filename: &str) -> TestFile {
 }
 
 async fn get_tenant_id_from_db(pool: &sqlx::PgPool, tenant_api_key: &str) -> i32 {
-    let tenant_id: i32 = sqlx::query_scalar("SELECT id FROM tenants WHERE tenant_api_key = $1")
-        .bind(tenant_api_key)
-        .fetch_one(pool)
-        .await
-        .expect("tenant_id");
+    let tenant_id: i32 =
+        sqlx::query_scalar("SELECT tenant_id FROM tenants WHERE tenant_api_key = $1::uuid")
+            .bind(tenant_api_key)
+            .fetch_one(pool)
+            .await
+            .expect("tenant_id");
 
     tenant_id
 }


### PR DESCRIPTION
- fixes #328 
- Update example sns keys in fhevm-keys with `tfhe 1.0.0`

An example run:
```
/target/release/sns_worker --tenant-api-key a1503fb6-d79b-4e9e-826d-44cf262f3e05 --pg-listen-channel notify_sns_worker --pg-notify-channel notify_computed
```