### PR TITLE
chore: add binary for helper tasks like ServerKey conversion

### DIFF
--- a/fhevm-engine/coprocessor/Cargo.toml
+++ b/fhevm-engine/coprocessor/Cargo.toml
@@ -67,6 +67,10 @@ path = "src/bin/coprocessor.rs"
 name = "cli"
 path = "src/bin/cli.rs"
 
+[[bin]]
+name = "utils"
+path = "src/bin/utils.rs"
+
 [[bench]]
 name = "erc20"
 path = "benches/erc20.rs"

--- a/fhevm-engine/coprocessor/Dockerfile
+++ b/fhevm-engine/coprocessor/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=build /app/fhevm-engine/target/release/sns_worker /usr/local/bin/sns
 COPY --from=build /app/fhevm-engine/target/release/transaction_sender /usr/local/bin/transaction_sender
 
 RUN groupadd -g 10001 zama && \
-     useradd -u 10000 -g zama zama && \
+    useradd -u 10000 -g zama zama && \
     chown -R zama:zama /usr/local/bin && \
     chmod 500 /usr/local/bin/coprocessor && \
     chmod 500 /usr/local/bin/cli && \

--- a/fhevm-engine/coprocessor/src/bin/utils.rs
+++ b/fhevm-engine/coprocessor/src/bin/utils.rs
@@ -1,24 +1,32 @@
 use std::{fs::read, path::Path};
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use fhevm_engine_common::utils::{safe_deserialize_sns_key, safe_serialize_key};
 use tfhe::ServerKey;
 use tracing::{error, info};
-#[derive(Parser, Debug, Clone)]
-#[command(version, about, long_about = None)]
-pub struct Args {
-    ///  Server key with noise squashing enabled
-    #[arg(long, default_value = "./sks_noise_squashing.bin")]
-    pub src_path: String,
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    #[clap(subcommand)]
+    command: Commands,
+}
 
-    /// Output server key with noise squashing disabled
-    #[arg(long, default_value = "./sks_key.bin")]
-    pub dst_path: String,
+#[derive(Debug, Subcommand)]
+enum Commands {
+    ExtractSksWithoutNoise {
+        /// Server key with noise squashing enabled
+        #[arg(long, default_value = "./sks_noise_squashing.bin")]
+        src_path: String,
+
+        /// Output server key with noise squashing disabled
+        #[arg(long, default_value = "./sks_key.bin")]
+        dst_path: String,
+    },
 }
 
 /// Extracts the server key without noise squashing from the given path and saves it to the destination path.
-pub fn extract_server_key_without_ns(src_path: String, dest_path: String) {
-    let dest_path = Path::new(&dest_path);
+pub fn extract_server_key_without_ns(src_path: String, dest_path: &String) -> bool {
+    let dest_path = Path::new(dest_path);
     let src_path = Path::new(&src_path);
     info!("Reading server key from file {:?}", src_path);
 
@@ -28,7 +36,7 @@ pub fn extract_server_key_without_ns(src_path: String, dest_path: String) {
     let (sks, kskm, compression_key, c, noise_squashing_key, tag) = server_key.into_raw_parts();
     if noise_squashing_key.is_none() {
         error!("Server key does not have noise squashing");
-        return;
+        return false;
     }
 
     info!("Creating file {:?}", dest_path);
@@ -43,15 +51,18 @@ pub fn extract_server_key_without_ns(src_path: String, dest_path: String) {
     ));
 
     std::fs::write(dest_path, bytes).expect("write sks");
+
+    true
 }
 
 fn main() {
     tracing_subscriber::fmt().with_level(true).init();
-
     let args = Args::parse();
-    extract_server_key_without_ns(args.src_path, args.dst_path.clone());
-    info!(
-        "Server key without noise squashing saved to {:?}",
-        args.dst_path
-    );
+    match args.command {
+        Commands::ExtractSksWithoutNoise { src_path, dst_path } => {
+            if extract_server_key_without_ns(src_path, &dst_path) {
+                info!("Server key without noise squashing saved to {:?}", dst_path);
+            }
+        }
+    }
 }

--- a/fhevm-engine/coprocessor/src/bin/utils.rs
+++ b/fhevm-engine/coprocessor/src/bin/utils.rs
@@ -1,0 +1,62 @@
+use std::{fs::read, path::Path};
+
+use clap::Parser;
+use fhevm_engine_common::utils::{safe_deserialize_sns_key, safe_serialize_key};
+use tfhe::ServerKey;
+use tracing::{error, info};
+#[derive(Parser, Debug, Clone)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    ///  Server key with noise squashing enabled
+    #[arg(long, default_value = "./sks_noise_squashing.bin")]
+    pub src_path: String,
+
+    /// Output server key with noise squashing disabled
+    #[arg(long, default_value = "./sks_key.bin")]
+    pub dst_path: String,
+}
+
+/// Extracts the server key without noise squashing from the given path and saves it to the destination path.
+pub fn extract_server_key_without_ns(src_path: String, dest_path: String) {
+    let dest_path = Path::new(&dest_path);
+    if dest_path.exists() {
+        error!("Destination file already exists");
+        return;
+    }
+
+    let src_path = Path::new(&src_path);
+    info!("Reading server key from file {:?}", src_path);
+
+    let server_key: ServerKey = safe_deserialize_sns_key(&read(src_path).expect("read server key"))
+        .expect("deserialize server key");
+
+    let (sks, kskm, compression_key, c, noise_squashing_key, tag) = server_key.into_raw_parts();
+    if noise_squashing_key.is_none() {
+        error!("Server key does not have noise squashing");
+        return;
+    }
+
+    info!("Creating file {:?}", dest_path);
+
+    let bytes: Vec<u8> = safe_serialize_key(&ServerKey::from_raw_parts(
+        sks,
+        kskm,
+        compression_key,
+        c,
+        None, // noise squashing key excluded
+        tag,
+    ));
+
+    std::fs::write(dest_path, bytes).expect("write sks");
+}
+
+fn main() {
+    tracing_subscriber::fmt().with_level(true).init();
+
+    let args = Args::parse();
+    extract_server_key_without_ns(args.src_path, args.dst_path.clone());
+    info!(
+        "Server key without noise squashing saved to {:?}",
+        args.dst_path
+    );
+}

--- a/fhevm-engine/coprocessor/src/bin/utils.rs
+++ b/fhevm-engine/coprocessor/src/bin/utils.rs
@@ -19,11 +19,6 @@ pub struct Args {
 /// Extracts the server key without noise squashing from the given path and saves it to the destination path.
 pub fn extract_server_key_without_ns(src_path: String, dest_path: String) {
     let dest_path = Path::new(&dest_path);
-    if dest_path.exists() {
-        error!("Destination file already exists");
-        return;
-    }
-
     let src_path = Path::new(&src_path);
     info!("Reading server key from file {:?}", src_path);
 

--- a/fhevm-engine/fhevm-db/Dockerfile
+++ b/fhevm-engine/fhevm-db/Dockerfile
@@ -1,24 +1,46 @@
 # Use the Rust image as the base
-FROM rust:1.85.0-slim
+FROM rust:1.85.0-bookworm AS build
 
 # Install dependencies and tools
+
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends protobuf-compiler && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy migrations and initialization script
+COPY fhevm-engine/ /fhevm-engine
+COPY ./proto/ ./proto/
+
+WORKDIR /fhevm-engine
+# Build utils binary
+# Currently, this utils is used only for keys converting. 
+# Later on, it will be extended to replace initialize_db.sh completely
+RUN cargo fetch && \
+    SQLX_OFFLINE=true cargo build --release -p coprocessor --bin utils
+
+FROM rust:1.85.0-bookworm AS final
+
+# Install required runtime dependencies only
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libpq-dev postgresql-client xxd && \
     cargo install sqlx-cli --version 0.7.2 --no-default-features --features postgres --locked && \
     groupadd -r zama && useradd -r -g zama zama && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Copy migrations and initialization script
 COPY fhevm-engine/fhevm-db/initialize_db.sh /initialize_db.sh
 COPY fhevm-engine/fhevm-db/migrations /migrations
+COPY  --from=build /fhevm-engine/target/release/utils /usr/local/bin/utils
 
 # Change ownership of the copied files to the non-root user
 RUN mkdir /fhevm-keys && \
     chown -R zama:zama /initialize_db.sh /migrations /fhevm-keys && \
     chmod +x /initialize_db.sh
 
+
 # Switch to the non-root user
-USER zama
+USER zama:zama
 
 # Run the initialization script as the entrypoint
 ENTRYPOINT ["/bin/bash", "/initialize_db.sh"]

--- a/fhevm-engine/fhevm-db/Dockerfile
+++ b/fhevm-engine/fhevm-db/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 
 # Copy migrations and initialization script
 COPY fhevm-engine/ /fhevm-engine
-COPY ./proto/ ./proto/
+COPY proto/ /proto/
 
 WORKDIR /fhevm-engine
 # Build utils binary

--- a/fhevm-engine/fhevm-db/initialize_db.sh
+++ b/fhevm-engine/fhevm-db/initialize_db.sh
@@ -39,7 +39,7 @@ KEY_ID_HEX="\\x${KEY_ID}"
 
 # Extract small ServerKey from ServerKey with noise squashing keys
 SKS_FILE="/tmp/sks"
-/usr/local/bin/utils --src-path $SNS_PK_FILE --dst-path $SKS_FILE
+/usr/local/bin/utils extract-sks-without-noise --src-path $SNS_PK_FILE --dst-path $SKS_FILE
 
 for file in "$PKS_FILE" "$SKS_FILE" "$PUBLIC_PARAMS_FILE" "$SNS_PK_FILE"; do
     if [[ ! -f $file ]]; then

--- a/fhevm-engine/fhevm-db/initialize_db.sh
+++ b/fhevm-engine/fhevm-db/initialize_db.sh
@@ -29,14 +29,17 @@ sqlx migrate run --source $MIGRATION_DIR || { echo "Failed to run migrations."; 
 
 echo "-------------- Start inserting keys for tenant: $TENANT_API_KEY --------------"
 
+
 CHAIN_ID=${CHAIN_ID:-"12345"}
 PKS_FILE=${PKS_FILE:-"$KEY_DIR/pks"}
-SKS_FILE=${SKS_FILE:-"$KEY_DIR/sks"}
 PUBLIC_PARAMS_FILE=${PUBLIC_PARAMS_FILE:-"$KEY_DIR/pp"}
 SNS_PK_FILE=${SNS_PK_FILE:-"$KEY_DIR/sns_pk"}
 KEY_ID=${KEY_ID:-"10f49fdf75a123370ce2e2b1c5cc0615fb6e78dd829d0d850470cdbc84f15c11"}
 KEY_ID_HEX="\\x${KEY_ID}"
 
+# Extract small ServerKey from ServerKey with noise squashing keys
+SKS_FILE="/tmp/sks"
+/usr/local/bin/utils --src-path $SNS_PK_FILE --dst-path $SKS_FILE
 
 for file in "$PKS_FILE" "$SKS_FILE" "$PUBLIC_PARAMS_FILE" "$SNS_PK_FILE"; do
     if [[ ! -f $file ]]; then


### PR DESCRIPTION
- Add a binary (utils) that extracts ServerKey without noise squashing keys.
- Update db-migration docker image to build and use `utils` executable to do conversion on deployment