### PR TITLE
fix: use CoprocessorSignerAlreadyVerified/Rejected

### DIFF
--- a/fhevm-engine/transaction-sender/contracts/InputVerification.sol
+++ b/fhevm-engine/transaction-sender/contracts/InputVerification.sol
@@ -7,14 +7,21 @@ contract InputVerification {
     event VerifyProofResponseCalled(uint256, bytes32[], bytes);
     event RejectProofResponseCalled(uint256);
 
-    error CoprocessorSignerAlreadyResponded(uint256 zkProofId, address signer);
+    error CoprocessorSignerAlreadyVerified(uint256 zkProofId, address signer);
+    error CoprocessorSignerAlreadyRejected(uint256 zkProofId, address signer);
 
-    bool alreadyRespondedRevert;
-    bool generalRevert;
+    bool alreadyVerifiedRevert;
+    bool alreadyRejectedRevert;
+    bool otherRevert;
 
-    constructor(bool _alreadyRespondedRevert, bool _generalRevert) {
-        alreadyRespondedRevert = _alreadyRespondedRevert;
-        generalRevert = _generalRevert;
+    constructor(
+        bool _alreadyVerifiedRevert,
+        bool _alreadyRejectedRevert,
+        bool _otherRevert
+    ) {
+        alreadyVerifiedRevert = _alreadyVerifiedRevert;
+        alreadyRejectedRevert = _alreadyRejectedRevert;
+        otherRevert = _otherRevert;
     }
 
     function verifyProofResponse(
@@ -22,24 +29,24 @@ contract InputVerification {
         bytes32[] calldata handles,
         bytes calldata signature
     ) public {
-        if (generalRevert) {
-            revert("General revert");
+        if (otherRevert) {
+            revert("Other revert");
         }
 
-        if (alreadyRespondedRevert) {
-            revert CoprocessorSignerAlreadyResponded(zkProofId, msg.sender);
+        if (alreadyVerifiedRevert) {
+            revert CoprocessorSignerAlreadyVerified(zkProofId, msg.sender);
         }
 
         emit VerifyProofResponseCalled(zkProofId, handles, signature);
     }
 
     function rejectProofResponse(uint256 zkProofId) public {
-        if (generalRevert) {
-            revert("General revert");
+        if (otherRevert) {
+            revert("Other revert");
         }
 
-        if (alreadyRespondedRevert) {
-            revert CoprocessorSignerAlreadyResponded(zkProofId, msg.sender);
+        if (alreadyRejectedRevert) {
+            revert CoprocessorSignerAlreadyRejected(zkProofId, msg.sender);
         }
 
         emit RejectProofResponseCalled(zkProofId);

--- a/fhevm-engine/transaction-sender/src/transaction_sender.rs
+++ b/fhevm-engine/transaction-sender/src/transaction_sender.rs
@@ -17,6 +17,7 @@ pub struct TransactionSender<P: Provider<Ethereum> + Clone + 'static> {
     operations: Vec<Arc<dyn ops::TransactionOperation<P>>>,
     input_verification_address: Address,
     ciphertext_commits_address: Address,
+    multichain_acl_address: Address,
     db_pool: Pool<Postgres>,
 }
 
@@ -70,13 +71,14 @@ impl<P: Provider<Ethereum> + Clone + 'static> TransactionSender<P> {
             operations,
             input_verification_address,
             ciphertext_commits_address,
+            multichain_acl_address,
             db_pool,
         })
     }
 
     pub async fn run(&self) -> anyhow::Result<()> {
-        info!(target: TXN_SENDER_TARGET, "Starting Transaction Sender with: {:?}, InputVerification: {}, CiphertextCommits: {}",
-            self.conf, self.input_verification_address, self.ciphertext_commits_address);
+        info!(target: TXN_SENDER_TARGET, "Starting Transaction Sender with: {:?}, InputVerification: {}, CiphertextCommits: {}, MultichainAcl: {}",
+            self.conf, self.input_verification_address, self.ciphertext_commits_address, self.multichain_acl_address);
 
         let mut join_set = JoinSet::new();
 

--- a/fhevm-engine/transaction-sender/tests/verify_proof_tests.rs
+++ b/fhevm-engine/transaction-sender/tests/verify_proof_tests.rs
@@ -3,7 +3,7 @@ use alloy::providers::WsConnect;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::{primitives::U256, sol_types::eip712_domain};
 use alloy::{providers::ProviderBuilder, signers::SignerSync, sol, sol_types::SolStruct};
-use common::{CiphertextCommits, TestEnvironment, InputVerification};
+use common::{CiphertextCommits, InputVerification, TestEnvironment};
 use futures_util::StreamExt;
 use rand::random;
 use serial_test::serial;
@@ -39,7 +39,16 @@ async fn verify_proof_response_success() -> anyhow::Result<()> {
             .await?,
         Some(env.wallet.default_signer().address()),
     );
-    let input_verification = InputVerification::deploy(&provider_deploy, false, false).await?;
+    let already_verified_revert = false;
+    let already_rejected_revert = false;
+    let other_revert = false;
+    let input_verification = InputVerification::deploy(
+        &provider_deploy,
+        already_verified_revert,
+        already_rejected_revert,
+        other_revert,
+    )
+    .await?;
     let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
     let txn_sender = TransactionSender::new(
         *input_verification.address(),
@@ -154,7 +163,16 @@ async fn verify_proof_response_concurrent_success() -> anyhow::Result<()> {
             .await?,
         Some(env.wallet.default_signer().address()),
     );
-    let input_verification = InputVerification::deploy(&provider_deploy, false, false).await?;
+    let already_verified_revert = false;
+    let already_rejected_revert = false;
+    let other_revert = false;
+    let input_verification = InputVerification::deploy(
+        &provider_deploy,
+        already_verified_revert,
+        already_rejected_revert,
+        other_revert,
+    )
+    .await?;
     let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
     let txn_sender = TransactionSender::new(
         *input_verification.address(),
@@ -257,414 +275,6 @@ async fn verify_proof_response_concurrent_success() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[serial(db)]
-async fn verify_proof_response_reversal_already_responded() -> anyhow::Result<()> {
-    let env = TestEnvironment::new().await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
-        .await?;
-    let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
-            .await?,
-        Some(env.wallet.default_signer().address()),
-    );
-    let input_verification = InputVerification::deploy(&provider_deploy, true, false).await?;
-    let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
-    let txn_sender = TransactionSender::new(
-        *input_verification.address(),
-        *ciphertext_manager.address(),
-        PrivateKeySigner::random().address(),
-        env.signer.clone(),
-        provider.clone(),
-        env.cancel_token.clone(),
-        env.conf.clone(),
-        None,
-    )
-    .await?;
-
-    let proof_id: u32 = random();
-
-    let run_handle = tokio::spawn(async move { txn_sender.run().await });
-
-    // Record initial transaction count.
-    let initial_tx_count = provider.get_transaction_count(env.signer.address()).await?;
-
-    // Insert a proof into the database and notify the sender.
-    sqlx::query!(
-        "WITH ins AS (
-            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
-            VALUES ($1, $2, $3, $4, $5, true)
-        )
-        SELECT pg_notify($6, '')",
-        proof_id as i64,
-        42,
-        env.contract_address.to_string(),
-        env.user_address.to_string(),
-        &[1u8; 64],
-        env.conf.verify_proof_resp_db_channel
-    )
-    .execute(&env.db_pool)
-    .await?;
-
-    // Make sure the proof is removed from the database.
-    loop {
-        let rows = sqlx::query!(
-            "SELECT *
-             FROM verify_proofs
-             WHERE zk_proof_id = $1",
-            proof_id as i64,
-        )
-        .fetch_all(&env.db_pool)
-        .await?;
-        if rows.is_empty() {
-            break;
-        }
-        sleep(Duration::from_millis(500)).await;
-    }
-
-    // Verify that no transaction has been sent.
-    let final_tx_count = provider.get_transaction_count(env.signer.address()).await?;
-    assert_eq!(
-        final_tx_count, initial_tx_count,
-        "Expected no new transaction to be sent"
-    );
-
-    env.cancel_token.cancel();
-    run_handle.await??;
-    Ok(())
-}
-
-#[tokio::test]
-#[serial(db)]
-async fn verify_proof_response_other_reversal_gas_estimation() -> anyhow::Result<()> {
-    let env = TestEnvironment::new().await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
-        .await?;
-    let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
-            .await?,
-        Some(env.wallet.default_signer().address()),
-    );
-    let input_verification = InputVerification::deploy(&provider_deploy, false, true).await?;
-    let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
-    let txn_sender = TransactionSender::new(
-        *input_verification.address(),
-        *ciphertext_manager.address(),
-        PrivateKeySigner::random().address(),
-        env.signer.clone(),
-        provider.clone(),
-        env.cancel_token.clone(),
-        env.conf.clone(),
-        None,
-    )
-    .await?;
-
-    let proof_id: u32 = random();
-
-    let run_handle = tokio::spawn(async move { txn_sender.run().await });
-
-    // Insert a proof into the database and notify the sender.
-    sqlx::query!(
-        "WITH ins AS (
-            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
-            VALUES ($1, $2, $3, $4, $5, true)
-        )
-        SELECT pg_notify($6, '')",
-        proof_id as i64,
-        42,
-        env.contract_address.to_string(),
-        env.user_address.to_string(),
-        &[1u8; 64],
-        env.conf.verify_proof_resp_db_channel
-    )
-    .execute(&env.db_pool)
-    .await?;
-
-    // Make sure the proof retry count is incremented.
-    //
-    // Note this is a racy test, because the retry count is incremented by the transaction sender and it might
-    // get to a point where retry count reaches max retries - then, transaction sender gives up and deletes the entry.
-    loop {
-        let rows = sqlx::query!(
-            "SELECT *
-             FROM verify_proofs
-             WHERE zk_proof_id = $1",
-            proof_id as i64,
-        )
-        .fetch_all(&env.db_pool)
-        .await?;
-        assert_eq!(rows.len(), 1);
-        if rows.first().unwrap().retry_count > 0 {
-            break;
-        }
-        sleep(Duration::from_millis(500)).await;
-    }
-
-    env.cancel_token.cancel();
-    run_handle.await??;
-
-    // Make sure the entry is removed at the end of the test.
-    sqlx::query("DELETE FROM verify_proofs WHERE zk_proof_id = $1")
-        .bind(proof_id as i64)
-        .execute(&env.db_pool)
-        .await?;
-    Ok(())
-}
-
-#[tokio::test]
-#[serial(db)]
-async fn verify_proof_response_other_reversal_receipt() -> anyhow::Result<()> {
-    let env = TestEnvironment::new().await?;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
-        .await?;
-    let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
-            .await?,
-        Some(env.wallet.default_signer().address()),
-    );
-    let input_verification = InputVerification::deploy(&provider_deploy, false, true).await?;
-    let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
-    // Create the sender with a gas limit such that no gas estimation is done, forcing failure at receipt (after the txn has been sent).
-    let txn_sender = TransactionSender::new(
-        *input_verification.address(),
-        *ciphertext_manager.address(),
-        PrivateKeySigner::random().address(),
-        env.signer.clone(),
-        provider.clone(),
-        env.cancel_token.clone(),
-        env.conf.clone(),
-        Some(1_000_000),
-    )
-    .await?;
-
-    let proof_id: u32 = random();
-
-    let run_handle = tokio::spawn(async move { txn_sender.run().await });
-
-    // Insert a proof into the database and notify the sender.
-    sqlx::query!(
-        "WITH ins AS (
-            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
-            VALUES ($1, $2, $3, $4, $5, true)
-        )
-        SELECT pg_notify($6, '')",
-        proof_id as i64,
-        42,
-        env.contract_address.to_string(),
-        env.user_address.to_string(),
-        &[1u8; 64],
-        env.conf.verify_proof_resp_db_channel
-    )
-    .execute(&env.db_pool)
-    .await?;
-
-    // Make sure the proof retry count is incremented.
-    //
-    // Note this is a racy test, because the retry count is incremented by the transaction sender and it might
-    // get to a point where retry count reaches max retries - then, transaction sender gives up and deletes the entry.
-    loop {
-        let rows = sqlx::query!(
-            "SELECT *
-             FROM verify_proofs
-             WHERE zk_proof_id = $1",
-            proof_id as i64,
-        )
-        .fetch_all(&env.db_pool)
-        .await?;
-        assert_eq!(rows.len(), 1);
-        if rows.first().unwrap().retry_count > 0 {
-            break;
-        }
-        sleep(Duration::from_millis(500)).await;
-    }
-
-    env.cancel_token.cancel();
-    run_handle.await??;
-
-    // Make sure the entry is removed at the end of the test.
-    sqlx::query("DELETE FROM verify_proofs WHERE zk_proof_id = $1")
-        .bind(proof_id as i64)
-        .execute(&env.db_pool)
-        .await?;
-    Ok(())
-}
-
-#[tokio::test]
-#[serial(db)]
-async fn verify_proof_max_retries_remove_entry() -> anyhow::Result<()> {
-    let mut env = TestEnvironment::new().await?;
-    env.conf.verify_proof_remove_after_max_retries = true;
-    env.conf.verify_proof_resp_max_retries = 2;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
-        .await?;
-    let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
-            .await?,
-        Some(env.wallet.default_signer().address()),
-    );
-    let input_verification = InputVerification::deploy(&provider_deploy, false, true).await?;
-    let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
-    let txn_sender = TransactionSender::new(
-        *input_verification.address(),
-        *ciphertext_manager.address(),
-        PrivateKeySigner::random().address(),
-        env.signer.clone(),
-        provider.clone(),
-        env.cancel_token.clone(),
-        env.conf.clone(),
-        None,
-    )
-    .await?;
-
-    let proof_id: u32 = random();
-
-    let run_handle = tokio::spawn(async move { txn_sender.run().await });
-
-    // Insert a proof into the database and notify the sender.
-    sqlx::query!(
-        "WITH ins AS (
-            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
-            VALUES ($1, $2, $3, $4, $5, true)
-        )
-        SELECT pg_notify($6, '')",
-        proof_id as i64,
-        42,
-        env.contract_address.to_string(),
-        env.user_address.to_string(),
-        &[1u8; 64],
-        env.conf.verify_proof_resp_db_channel
-    )
-    .execute(&env.db_pool)
-    .await?;
-
-    // Make sure the proof is removed from the database.
-    loop {
-        let rows = sqlx::query!(
-            "SELECT *
-             FROM verify_proofs
-             WHERE zk_proof_id = $1",
-            proof_id as i64,
-        )
-        .fetch_all(&env.db_pool)
-        .await?;
-        if rows.is_empty() {
-            break;
-        }
-        sleep(Duration::from_millis(500)).await;
-    }
-
-    env.cancel_token.cancel();
-    run_handle.await??;
-    Ok(())
-}
-
-#[tokio::test]
-#[serial(db)]
-async fn verify_proof_max_retries_do_not_remove_entry() -> anyhow::Result<()> {
-    let mut env = TestEnvironment::new().await?;
-    env.conf.verify_proof_remove_after_max_retries = false;
-    env.conf.verify_proof_resp_max_retries = 2;
-    let provider_deploy = ProviderBuilder::new()
-        .wallet(env.wallet.clone())
-        .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
-        .await?;
-    let provider = NonceManagedProvider::new(
-        ProviderBuilder::default()
-            .filler(FillersWithoutNonceManagement::default())
-            .wallet(env.wallet.clone())
-            .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
-            .await?,
-        Some(env.wallet.default_signer().address()),
-    );
-    let input_verification = InputVerification::deploy(&provider_deploy, false, true).await?;
-    let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
-    let txn_sender = TransactionSender::new(
-        *input_verification.address(),
-        *ciphertext_manager.address(),
-        PrivateKeySigner::random().address(),
-        env.signer.clone(),
-        provider.clone(),
-        env.cancel_token.clone(),
-        env.conf.clone(),
-        None,
-    )
-    .await?;
-
-    let proof_id: u32 = random();
-
-    let run_handle = tokio::spawn(async move { txn_sender.run().await });
-
-    // Insert a proof into the database and notify the sender.
-    sqlx::query!(
-        "WITH ins AS (
-            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
-            VALUES ($1, $2, $3, $4, $5, true)
-        )
-        SELECT pg_notify($6, '')",
-        proof_id as i64,
-        42,
-        env.contract_address.to_string(),
-        env.user_address.to_string(),
-        &[1u8; 64],
-        env.conf.verify_proof_resp_db_channel
-    )
-    .execute(&env.db_pool)
-    .await?;
-
-    // Wait until retry_count = 2.
-    loop {
-        let rows = sqlx::query!(
-            "SELECT *
-             FROM verify_proofs
-             WHERE zk_proof_id = $1 AND retry_count = 2 AND verified = true",
-            proof_id as i64,
-        )
-        .fetch_all(&env.db_pool)
-        .await?;
-        if !rows.is_empty() {
-            break;
-        }
-        sleep(Duration::from_millis(500)).await;
-    }
-
-    // Stop the transaction sender.
-    env.cancel_token.cancel();
-    run_handle.await??;
-
-    // Make sure the entry is not removed.
-    let rows = sqlx::query!(
-        "SELECT *
-         FROM verify_proofs
-         WHERE zk_proof_id = $1 AND retry_count = 2 AND verified = true",
-        proof_id as i64,
-    )
-    .fetch_all(&env.db_pool)
-    .await?;
-    assert_eq!(rows.len(), 1);
-
-    Ok(())
-}
-
-#[tokio::test]
-#[serial(db)]
 async fn reject_proof_response_success() -> anyhow::Result<()> {
     let env = TestEnvironment::new().await?;
     let provider_deploy = ProviderBuilder::new()
@@ -679,7 +289,16 @@ async fn reject_proof_response_success() -> anyhow::Result<()> {
             .await?,
         Some(env.wallet.default_signer().address()),
     );
-    let input_verification = InputVerification::deploy(&provider_deploy, false, false).await?;
+    let already_verified_revert = false;
+    let already_rejected_revert = false;
+    let other_revert = false;
+    let input_verification = InputVerification::deploy(
+        &provider_deploy,
+        already_verified_revert,
+        already_rejected_revert,
+        other_revert,
+    )
+    .await?;
     let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
     let txn_sender = TransactionSender::new(
         *input_verification.address(),
@@ -759,7 +378,7 @@ async fn reject_proof_response_success() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[serial(db)]
-async fn reject_proof_response_reversal_already_responded() -> anyhow::Result<()> {
+async fn verify_proof_response_reversal_already_verified() -> anyhow::Result<()> {
     let env = TestEnvironment::new().await?;
     let provider_deploy = ProviderBuilder::new()
         .wallet(env.wallet.clone())
@@ -773,7 +392,107 @@ async fn reject_proof_response_reversal_already_responded() -> anyhow::Result<()
             .await?,
         Some(env.wallet.default_signer().address()),
     );
-    let input_verification = InputVerification::deploy(&provider_deploy, true, false).await?;
+    let already_verified_revert = true;
+    let already_rejected_revert = false;
+    let other_revert = false;
+    let input_verification = InputVerification::deploy(
+        &provider_deploy,
+        already_verified_revert,
+        already_rejected_revert,
+        other_revert,
+    )
+    .await?;
+    let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
+    let txn_sender = TransactionSender::new(
+        *input_verification.address(),
+        *ciphertext_manager.address(),
+        PrivateKeySigner::random().address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+
+    let proof_id: u32 = random();
+
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+
+    // Record initial transaction count.
+    let initial_tx_count = provider.get_transaction_count(env.signer.address()).await?;
+
+    // Insert a proof into the database and notify the sender.
+    sqlx::query!(
+        "WITH ins AS (
+            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
+            VALUES ($1, $2, $3, $4, $5, true)
+        )
+        SELECT pg_notify($6, '')",
+        proof_id as i64,
+        42,
+        env.contract_address.to_string(),
+        env.user_address.to_string(),
+        &[1u8; 64],
+        env.conf.verify_proof_resp_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    // Make sure the proof is removed from the database.
+    loop {
+        let rows = sqlx::query!(
+            "SELECT *
+             FROM verify_proofs
+             WHERE zk_proof_id = $1",
+            proof_id as i64,
+        )
+        .fetch_all(&env.db_pool)
+        .await?;
+        if rows.is_empty() {
+            break;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    // Verify that no transaction has been sent.
+    let final_tx_count = provider.get_transaction_count(env.signer.address()).await?;
+    assert_eq!(
+        final_tx_count, initial_tx_count,
+        "Expected no new transaction to be sent"
+    );
+
+    env.cancel_token.cancel();
+    run_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn reject_proof_response_reversal_already_rejected() -> anyhow::Result<()> {
+    let env = TestEnvironment::new().await?;
+    let provider_deploy = ProviderBuilder::new()
+        .wallet(env.wallet.clone())
+        .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
+        .await?;
+    let provider = NonceManagedProvider::new(
+        ProviderBuilder::default()
+            .filler(FillersWithoutNonceManagement::default())
+            .wallet(env.wallet.clone())
+            .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
+            .await?,
+        Some(env.wallet.default_signer().address()),
+    );
+    let already_verified_revert = false;
+    let already_rejected_revert = true;
+    let other_revert = false;
+    let input_verification = InputVerification::deploy(
+        &provider_deploy,
+        already_verified_revert,
+        already_rejected_revert,
+        other_revert,
+    )
+    .await?;
     let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
     let txn_sender = TransactionSender::new(
         *input_verification.address(),
@@ -840,7 +559,7 @@ async fn reject_proof_response_reversal_already_responded() -> anyhow::Result<()
 
 #[tokio::test]
 #[serial(db)]
-async fn reject_proof_response_other_reversal_receipt() -> anyhow::Result<()> {
+async fn verify_proof_response_other_reversal() -> anyhow::Result<()> {
     let env = TestEnvironment::new().await?;
     let provider_deploy = ProviderBuilder::new()
         .wallet(env.wallet.clone())
@@ -854,7 +573,108 @@ async fn reject_proof_response_other_reversal_receipt() -> anyhow::Result<()> {
             .await?,
         Some(env.wallet.default_signer().address()),
     );
-    let input_verification = InputVerification::deploy(&provider_deploy, false, true).await?;
+    let already_verified_revert = false;
+    let already_rejected_revert = false;
+    let other_revert = true;
+    let input_verification = InputVerification::deploy(
+        &provider_deploy,
+        already_verified_revert,
+        already_rejected_revert,
+        other_revert,
+    )
+    .await?;
+    let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
+    // Create the sender with a gas limit such that no gas estimation is done, forcing failure at receipt (after the txn has been sent).
+    let txn_sender = TransactionSender::new(
+        *input_verification.address(),
+        *ciphertext_manager.address(),
+        PrivateKeySigner::random().address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        Some(1_000_000),
+    )
+    .await?;
+
+    let proof_id: u32 = random();
+
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+
+    // Insert a proof into the database and notify the sender.
+    sqlx::query!(
+        "WITH ins AS (
+            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
+            VALUES ($1, $2, $3, $4, $5, true)
+        )
+        SELECT pg_notify($6, '')",
+        proof_id as i64,
+        42,
+        env.contract_address.to_string(),
+        env.user_address.to_string(),
+        &[1u8; 64],
+        env.conf.verify_proof_resp_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    // Make sure the proof retry count is incremented.
+    //
+    // Note this is a racy test, because the retry count is incremented by the transaction sender and it might
+    // get to a point where retry count reaches max retries - then, transaction sender gives up and deletes the entry.
+    loop {
+        let rows = sqlx::query!(
+            "SELECT *
+             FROM verify_proofs
+             WHERE zk_proof_id = $1",
+            proof_id as i64,
+        )
+        .fetch_all(&env.db_pool)
+        .await?;
+        assert_eq!(rows.len(), 1);
+        if rows.first().unwrap().retry_count > 0 {
+            break;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    env.cancel_token.cancel();
+    run_handle.await??;
+
+    // Make sure the entry is removed at the end of the test.
+    sqlx::query("DELETE FROM verify_proofs WHERE zk_proof_id = $1")
+        .bind(proof_id as i64)
+        .execute(&env.db_pool)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn reject_proof_response_other_reversal() -> anyhow::Result<()> {
+    let env = TestEnvironment::new().await?;
+    let provider_deploy = ProviderBuilder::new()
+        .wallet(env.wallet.clone())
+        .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
+        .await?;
+    let provider = NonceManagedProvider::new(
+        ProviderBuilder::default()
+            .filler(FillersWithoutNonceManagement::default())
+            .wallet(env.wallet.clone())
+            .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
+            .await?,
+        Some(env.wallet.default_signer().address()),
+    );
+    let already_verified_revert = false;
+    let already_rejected_revert = false;
+    let other_revert = true;
+    let input_verification = InputVerification::deploy(
+        &provider_deploy,
+        already_verified_revert,
+        already_rejected_revert,
+        other_revert,
+    )
+    .await?;
     let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
     // Create the sender with a gas limit such that no gas estimation is done, forcing failure at receipt (after the txn has been sent).
     let txn_sender = TransactionSender::new(
@@ -919,6 +739,97 @@ async fn reject_proof_response_other_reversal_receipt() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[serial(db)]
+async fn verify_proof_response_other_reversal_gas_estimation() -> anyhow::Result<()> {
+    let env = TestEnvironment::new().await?;
+    let provider_deploy = ProviderBuilder::new()
+        .wallet(env.wallet.clone())
+        .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
+        .await?;
+    let provider = NonceManagedProvider::new(
+        ProviderBuilder::default()
+            .filler(FillersWithoutNonceManagement::default())
+            .wallet(env.wallet.clone())
+            .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
+            .await?,
+        Some(env.wallet.default_signer().address()),
+    );
+    let already_verified_revert = false;
+    let already_rejected_revert = false;
+    let other_revert = true;
+    let input_verification = InputVerification::deploy(
+        &provider_deploy,
+        already_verified_revert,
+        already_rejected_revert,
+        other_revert,
+    )
+    .await?;
+    let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
+    let txn_sender = TransactionSender::new(
+        *input_verification.address(),
+        *ciphertext_manager.address(),
+        PrivateKeySigner::random().address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+
+    let proof_id: u32 = random();
+
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+
+    // Insert a proof into the database and notify the sender.
+    sqlx::query!(
+        "WITH ins AS (
+            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
+            VALUES ($1, $2, $3, $4, $5, true)
+        )
+        SELECT pg_notify($6, '')",
+        proof_id as i64,
+        42,
+        env.contract_address.to_string(),
+        env.user_address.to_string(),
+        &[1u8; 64],
+        env.conf.verify_proof_resp_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    // Make sure the proof retry count is incremented.
+    //
+    // Note this is a racy test, because the retry count is incremented by the transaction sender and it might
+    // get to a point where retry count reaches max retries - then, transaction sender gives up and deletes the entry.
+    loop {
+        let rows = sqlx::query!(
+            "SELECT *
+             FROM verify_proofs
+             WHERE zk_proof_id = $1",
+            proof_id as i64,
+        )
+        .fetch_all(&env.db_pool)
+        .await?;
+        assert_eq!(rows.len(), 1);
+        if rows.first().unwrap().retry_count > 0 {
+            break;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    env.cancel_token.cancel();
+    run_handle.await??;
+
+    // Make sure the entry is removed at the end of the test.
+    sqlx::query("DELETE FROM verify_proofs WHERE zk_proof_id = $1")
+        .bind(proof_id as i64)
+        .execute(&env.db_pool)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial(db)]
 async fn reject_proof_response_other_reversal_gas_estimation() -> anyhow::Result<()> {
     let env = TestEnvironment::new().await?;
     let provider_deploy = ProviderBuilder::new()
@@ -933,7 +844,16 @@ async fn reject_proof_response_other_reversal_gas_estimation() -> anyhow::Result
             .await?,
         Some(env.wallet.default_signer().address()),
     );
-    let input_verification = InputVerification::deploy(&provider_deploy, false, true).await?;
+    let already_verified_revert = false;
+    let already_rejected_revert = false;
+    let other_revert = true;
+    let input_verification = InputVerification::deploy(
+        &provider_deploy,
+        already_verified_revert,
+        already_rejected_revert,
+        other_revert,
+    )
+    .await?;
     let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
     let txn_sender = TransactionSender::new(
         *input_verification.address(),
@@ -996,5 +916,184 @@ async fn reject_proof_response_other_reversal_gas_estimation() -> anyhow::Result
         .bind(proof_id as i64)
         .execute(&env.db_pool)
         .await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn verify_proof_max_retries_remove_entry() -> anyhow::Result<()> {
+    let mut env = TestEnvironment::new().await?;
+    env.conf.verify_proof_remove_after_max_retries = true;
+    env.conf.verify_proof_resp_max_retries = 2;
+    let provider_deploy = ProviderBuilder::new()
+        .wallet(env.wallet.clone())
+        .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
+        .await?;
+    let provider = NonceManagedProvider::new(
+        ProviderBuilder::default()
+            .filler(FillersWithoutNonceManagement::default())
+            .wallet(env.wallet.clone())
+            .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
+            .await?,
+        Some(env.wallet.default_signer().address()),
+    );
+    let already_verified_revert = false;
+    let already_rejected_revert = false;
+    let other_revert = true;
+    let input_verification = InputVerification::deploy(
+        &provider_deploy,
+        already_verified_revert,
+        already_rejected_revert,
+        other_revert,
+    )
+    .await?;
+    let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
+    let txn_sender = TransactionSender::new(
+        *input_verification.address(),
+        *ciphertext_manager.address(),
+        PrivateKeySigner::random().address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+
+    let proof_id: u32 = random();
+
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+
+    // Insert a proof into the database and notify the sender.
+    sqlx::query!(
+        "WITH ins AS (
+            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
+            VALUES ($1, $2, $3, $4, $5, true)
+        )
+        SELECT pg_notify($6, '')",
+        proof_id as i64,
+        42,
+        env.contract_address.to_string(),
+        env.user_address.to_string(),
+        &[1u8; 64],
+        env.conf.verify_proof_resp_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    // Make sure the proof is removed from the database.
+    loop {
+        let rows = sqlx::query!(
+            "SELECT *
+             FROM verify_proofs
+             WHERE zk_proof_id = $1",
+            proof_id as i64,
+        )
+        .fetch_all(&env.db_pool)
+        .await?;
+        if rows.is_empty() {
+            break;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    env.cancel_token.cancel();
+    run_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial(db)]
+async fn verify_proof_max_retries_do_not_remove_entry() -> anyhow::Result<()> {
+    let mut env = TestEnvironment::new().await?;
+    env.conf.verify_proof_remove_after_max_retries = false;
+    env.conf.verify_proof_resp_max_retries = 2;
+    let provider_deploy = ProviderBuilder::new()
+        .wallet(env.wallet.clone())
+        .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
+        .await?;
+    let provider = NonceManagedProvider::new(
+        ProviderBuilder::default()
+            .filler(FillersWithoutNonceManagement::default())
+            .wallet(env.wallet.clone())
+            .on_ws(WsConnect::new(env.anvil.ws_endpoint_url()))
+            .await?,
+        Some(env.wallet.default_signer().address()),
+    );
+    let already_verified_revert = false;
+    let already_rejected_revert = false;
+    let other_revert = true;
+    let input_verification = InputVerification::deploy(
+        &provider_deploy,
+        already_verified_revert,
+        already_rejected_revert,
+        other_revert,
+    )
+    .await?;
+    let ciphertext_manager = CiphertextCommits::deploy(&provider_deploy).await?;
+    let txn_sender = TransactionSender::new(
+        *input_verification.address(),
+        *ciphertext_manager.address(),
+        PrivateKeySigner::random().address(),
+        env.signer.clone(),
+        provider.clone(),
+        env.cancel_token.clone(),
+        env.conf.clone(),
+        None,
+    )
+    .await?;
+
+    let proof_id: u32 = random();
+
+    let run_handle = tokio::spawn(async move { txn_sender.run().await });
+
+    // Insert a proof into the database and notify the sender.
+    sqlx::query!(
+        "WITH ins AS (
+            INSERT INTO verify_proofs (zk_proof_id, chain_id, contract_address, user_address, handles, verified)
+            VALUES ($1, $2, $3, $4, $5, true)
+        )
+        SELECT pg_notify($6, '')",
+        proof_id as i64,
+        42,
+        env.contract_address.to_string(),
+        env.user_address.to_string(),
+        &[1u8; 64],
+        env.conf.verify_proof_resp_db_channel
+    )
+    .execute(&env.db_pool)
+    .await?;
+
+    // Wait until retry_count = 2.
+    loop {
+        let rows = sqlx::query!(
+            "SELECT *
+             FROM verify_proofs
+             WHERE zk_proof_id = $1 AND retry_count = 2 AND verified = true",
+            proof_id as i64,
+        )
+        .fetch_all(&env.db_pool)
+        .await?;
+        if !rows.is_empty() {
+            break;
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    // Stop the transaction sender.
+    env.cancel_token.cancel();
+    run_handle.await??;
+
+    // Make sure the entry is not removed.
+    let rows = sqlx::query!(
+        "SELECT *
+         FROM verify_proofs
+         WHERE zk_proof_id = $1 AND retry_count = 2 AND verified = true",
+        proof_id as i64,
+    )
+    .fetch_all(&env.db_pool)
+    .await?;
+    assert_eq!(rows.len(), 1);
+
     Ok(())
 }


### PR DESCRIPTION
Use the `CoprocessorSignerAlreadyVerified` and
`CoprocessorSignerAlreadyRejected` errors s.t. we are in sync with the
Gateway contracts.