### PR TITLE
feat: add etherscan URLs for zwsDev

### DIFF
--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -135,7 +135,21 @@ const config: HardhatUserConfig = {
     },
   },
   etherscan: {
-    apiKey: process.env.ETHERSCAN_API_KEY!,
+    apiKey: {
+      mainnet: process.env.ETHERSCAN_API_KEY!,
+      sepolia: process.env.ETHERSCAN_API_KEY!,
+      zwsDev: 'empty',
+    },
+    customChains: [
+      {
+        network: 'zwsDev',
+        chainId: 1337,
+        urls: {
+          apiURL: 'http://l1-blockscout-zws-dev-blockscout-stack-blockscout-svc/api',
+          browserURL: 'https://l1-explorer-zws-dev.diplodocus-boa.ts.net',
+        },
+      },
+    ],
   },
   warnings: {
     '*': {


### PR DESCRIPTION
This is required for smart contract verification on our Internal dev blockscout.