### PR TITLE
feat(sns-worker): enable parallel uploads of ciphertexts to S3 buckets

### DIFF
--- a/fhevm-engine/sns-executor/src/bin/utils/daemon_cli.rs
+++ b/fhevm-engine/sns-executor/src/bin/utils/daemon_cli.rs
@@ -49,6 +49,10 @@ pub struct Args {
     /// See also: general purpose buckets naming rules
     #[arg(long, default_value = "ct64")]
     pub bucket_name_ct64: String,
+
+    /// Maximum number of concurrent uploads to S3
+    #[arg(long, default_value_t = 100)]
+    pub max_concurrent_uploads: u32,
 }
 
 pub fn parse_args() -> Args {

--- a/fhevm-engine/sns-executor/src/lib.rs
+++ b/fhevm-engine/sns-executor/src/lib.rs
@@ -36,6 +36,7 @@ pub struct DBConfig {
 pub struct S3Config {
     pub bucket_ct128: String,
     pub bucket_ct64: String,
+    pub max_concurrent_uploads: u32,
 }
 
 #[derive(Clone)]
@@ -57,6 +58,7 @@ impl std::fmt::Display for Config {
     }
 }
 
+#[derive(Clone)]
 pub struct HandleItem {
     pub tenant_id: i32,
     pub handle: Vec<u8>,


### PR DESCRIPTION
Add a max_concurrent_uploads conf parameter to control the concurrency limit. Emit a warning when the maximum limit is reached to prompt manual intervention.

The uploading task is triggered as soon as the ct128 is computed.

fixes #568 