### PR TITLE
feat(sns-worker): implement  retry mechanism for the uploader

### DIFF
--- a/fhevm-engine/sns-executor/Cargo.toml
+++ b/fhevm-engine/sns-executor/Cargo.toml
@@ -23,6 +23,11 @@ serde = { workspace = true }
 sqlx = { workspace = true }
 tfhe-versionable = { workspace = true }
 tokio-util = { workspace = true }
+# opentelemetry support
+opentelemetry = { workspace = true }
+opentelemetry-otlp = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-semantic-conventions = { workspace = true }
 
 # crates.io dependencies
 hex = "=0.4"
@@ -33,6 +38,7 @@ serde_json = "=1.0"
 aws-sdk-s3 = "=1.78"
 aws-config = "=1.5"
 bytesize = "=2.0.1"
+futures = "0.3"
 
 
 # local dependencies

--- a/fhevm-engine/sns-executor/src/aws_upload.rs
+++ b/fhevm-engine/sns-executor/src/aws_upload.rs
@@ -1,35 +1,43 @@
 use crate::{Config, ExecutionError, HandleItem, S3Config};
+use aws_config::retry::RetryConfig;
+use aws_config::timeout::TimeoutConfig;
 use aws_config::BehaviorVersion;
+use aws_sdk_s3::config::Builder;
+use aws_sdk_s3::error::SdkError;
+use aws_sdk_s3::operation::head_bucket::HeadBucketError;
+use aws_sdk_s3::operation::head_object::HeadObjectError;
 use aws_sdk_s3::Client;
 use bytesize::ByteSize;
 use fhevm_engine_common::telemetry::{self};
 use fhevm_engine_common::utils::compact_hex;
+use futures::future::join_all;
 use sha3::{Digest, Keccak256};
 
+use opentelemetry::global::BoxedSpan;
 use sqlx::postgres::PgPoolOptions;
-use sqlx::PgPool;
+use sqlx::{PgPool, Pool, Postgres, Transaction};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
+use tokio::select;
 use tokio::sync::{mpsc, Semaphore};
 use tokio::task::JoinHandle;
-use tokio::{join, select};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 // TODO: Use a config TOML to set these values
 pub const EVENT_CIPHERTEXTS_UPLOADED: &str = "event_ciphertexts_uploaded";
-pub const UPLOAD_TIMEOUT_DURATION: Duration = Duration::from_secs(10);
 
 /// Process the S3 uploads
 pub(crate) async fn process_s3_uploads(
     conf: &Config,
     mut tasks: mpsc::Receiver<HandleItem>,
+    tasks_tx: mpsc::Sender<HandleItem>,
     token: CancellationToken,
 ) -> Result<(), ExecutionError> {
     // Client construction is expensive due to connection thread pool initialization, and should
     // be done once at application start-up.
-    let sdk_config = aws_config::load_defaults(BehaviorVersion::latest()).await;
-    let client = Arc::new(aws_sdk_s3::Client::new(&sdk_config));
+    let (client, is_ready) = create_s3_client(conf).await;
 
     let pool = Arc::new(
         PgPoolOptions::new()
@@ -37,6 +45,22 @@ pub(crate) async fn process_s3_uploads(
             .connect(&conf.db.url)
             .await?,
     );
+
+    let is_ready = Arc::new(AtomicBool::new(is_ready));
+    let cl = client.clone();
+    let r = is_ready.clone();
+    let c = conf.clone();
+    let t = token.clone();
+    let p = pool.clone();
+    tokio::spawn({
+        async move {
+            do_resubmits_loop(cl, p, &c, tasks_tx, t, r)
+                .await
+                .unwrap_or_else(|err| {
+                    error!("Failed to spawn do_resubmits_loop: {}", err);
+                });
+        }
+    });
 
     let conf = &conf.s3;
     let max_concurrent_uploads = conf.max_concurrent_uploads as usize;
@@ -50,6 +74,17 @@ pub(crate) async fn process_s3_uploads(
                     Some(task) => task,
                     None => return Ok(()),
                 };
+
+                let trx = insert_and_lock(task.tenant_id, task.handle.clone(), &pool).await?;
+
+                if !is_ready.load(Ordering::SeqCst) {
+                    // If the S3 setup is not ready, we need to wait for its ready status
+                    // before we can continue spawning uploading job
+                    info!("Upload task skipped, S3 connection still not ready");
+                    // Queue the uploading job in the database
+                    trx.commit().await?;
+                    continue;
+                }
 
                 // Cleanup completed tasks
                 upload_jobs.retain(|h| !h.is_finished());
@@ -70,14 +105,24 @@ pub(crate) async fn process_s3_uploads(
                 // Acquire a permit for an upload
                 let permit = semaphore.clone().acquire_owned().await.expect("Failed to acquire semaphore permit");
                 let client = client.clone();
-                let pool = pool.clone();
                 let conf = conf.clone();
+                let ready_flag = is_ready.clone();
 
                 // Spawn a new task to upload the ciphertexts
                 let h = tokio::spawn(async move {
-                        if let Err(err) = upload_ciphertexts(task, &client, &pool, &conf).await {
-                            error!("Failed to upload ciphertexts: {}", err);
-                            // TODO: Implement retry-mechanism.
+                    let s = task.otel.child_span("upload_s3");
+                        if let Err(err) = upload_ciphertexts(trx, task, &client, &conf).await {
+                            if let ExecutionError::S3TransientError(_) = err {
+                                ready_flag.store(false, Ordering::SeqCst );
+                                info!("S3 setup is not ready, due to transient error: {}", err);
+                            }else {
+                                error!("Failed to upload ciphertexts: {}", err);
+                            }
+
+                            telemetry::end_span_with_err(s, err.to_string());
+
+                        } else {
+                            telemetry::end_span(s);
                         }
                         drop(permit);
                 });
@@ -96,9 +141,48 @@ pub(crate) async fn process_s3_uploads(
                 }
 
                 return Ok(())
-            },
+            }
         }
     }
+}
+
+async fn insert_and_lock(
+    tenant_id: i32,
+    handle: Vec<u8>,
+    pool: &PgPool,
+) -> Result<Transaction<'static, Postgres>, ExecutionError> {
+    let mut trx = pool.begin().await?;
+
+    sqlx::query!(
+        "INSERT INTO ciphertext_digest (tenant_id, handle)
+        VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        tenant_id,
+        &handle,
+    )
+    .execute(trx.as_mut())
+    .await?;
+
+    trx.commit().await?;
+
+    let mut trx = pool.begin().await?;
+
+    sqlx::query!(
+        "SELECT * FROM ciphertext_digest
+        WHERE handle = $2 AND tenant_id = $1 AND
+        (ciphertext128 IS NULL OR ciphertext IS NULL)
+        FOR UPDATE SKIP LOCKED",
+        tenant_id,
+        handle,
+    )
+    .fetch_all(trx.as_mut())
+    .await?;
+
+    Ok(trx)
+}
+
+enum UploadResult {
+    CtType128((Vec<u8>, BoxedSpan)),
+    CtType64((Vec<u8>, BoxedSpan)),
 }
 
 /// Uploads both 128-bit bootstrapped ciphertext and regular ciphertext to S3
@@ -110,170 +194,441 @@ pub(crate) async fn process_s3_uploads(
 /// - If the upload of the regular ciphertext fails, the function will not store
 ///   its digest in the database.
 async fn upload_ciphertexts(
+    mut trx: Transaction<'_, Postgres>,
     task: HandleItem,
     client: &Client,
-    pool: &PgPool,
     conf: &S3Config,
 ) -> Result<(), ExecutionError> {
     let handle_as_hex: String = compact_hex(&task.handle);
-    info!("Received uploading task, handle: {}", handle_as_hex);
+    info!("Received task, handle: {}", handle_as_hex);
 
-    let ct128_bytes = match task.ct128_uncompressed {
-        Some(ct) => ct,
-        None => {
-            return Err(ExecutionError::MissingCiphertext128(handle_as_hex));
-        }
-    };
+    let mut jobs = vec![];
 
-    let s = task.otel.child_span("compute_digest");
-    let ct128_digest = compute_digest(&ct128_bytes);
-    let ct64_digest = compute_digest(&task.ct64_compressed);
-    telemetry::end_span(s);
-
-    info!(
-        "Start uploading task, handle: {}, tenant_id: {}, ct128_len: {}, ct64_compressed_len: {}",
-        handle_as_hex,
-        task.tenant_id,
-        ByteSize::b(ct128_bytes.len() as u64),
-        ByteSize::b(task.ct64_compressed.len() as u64)
-    );
-
-    let s = task.otel.child_span("s3_upload");
-    let (up1, up2) = join!(
-        tokio::time::timeout(
-            3 * UPLOAD_TIMEOUT_DURATION,
-            client
-                .put_object()
-                .bucket(conf.bucket_ct128.clone())
-                .key(hex::encode(&ct128_digest))
-                .body(ct128_bytes.into())
-                .send(),
-        ),
-        tokio::time::timeout(
-            UPLOAD_TIMEOUT_DURATION,
-            client
-                .put_object()
-                .bucket(conf.bucket_ct64.clone())
-                .key(hex::encode(&ct64_digest))
-                .body(task.ct64_compressed.into())
-                .send(),
-        )
-    );
-
-    let upload_finish_time = SystemTime::now();
-
-    let mut trx = pool.begin().await?;
-
-    sqlx::query!(
-        "INSERT INTO ciphertext_digest (tenant_id, handle)
-        VALUES ($1, $2)",
-        task.tenant_id,
-        task.handle,
-    )
-    .execute(trx.as_mut())
-    .await?;
-
-    let mut ct128_uploaded = false;
-    // Insert digest for ct128 only if ct128 upload was successful
-    match &up1 {
-        Ok(Ok(_)) => {
-            ct128_uploaded = true;
-            sqlx::query!(
-                "UPDATE ciphertext_digest
-                 SET ciphertext128 = $1
-                 WHERE handle = $2",
-                ct128_digest,
-                task.handle
-            )
-            .execute(trx.as_mut())
-            .await?;
-
-            // Reset ciphertext128 as the ct128 has been successfully uploaded to S3
-            // NB: For reclaiming the disk-space in DB, we rely on auto vacuuming in
-            // Postgres
-            sqlx::query!(
-                "UPDATE ciphertexts
-                     SET ciphertext128 = NULL
-                     WHERE handle = $1",
-                task.handle
-            )
-            .execute(trx.as_mut())
-            .await?;
-        }
-        Ok(Err(err)) => {
-            error!(
-                "Failed to upload ct128, handle: {}, err: {}",
-                handle_as_hex, err
-            );
-        }
-        Err(err) => {
-            error!(
-                "Failed to upload ct128, handle: {}, err: {}",
-                handle_as_hex, err
-            );
-        }
-    };
-
-    // Insert digest for ct64 only if ct64 upload was successful
-    let mut ct64_uploaded = false;
-    match &up2 {
-        Ok(Ok(_)) => {
-            ct64_uploaded = true;
-            sqlx::query!(
-                "UPDATE ciphertext_digest
-                 SET ciphertext = $1
-                 WHERE handle = $2",
-                ct64_digest,
-                task.handle
-            )
-            .execute(trx.as_mut())
-            .await?;
-        }
-        Ok(Err(err)) => {
-            error!(
-                "Failed to upload ct64, handle: {}, err: {}",
-                handle_as_hex, err
-            );
-        }
-        Err(err) => {
-            error!(
-                "Failed to upload ct64, handle: {}, err: {}",
-                handle_as_hex, err
-            );
-        }
-    }
-
-    // If both uploads are successful, notify the Transaction Sender
-    if ct128_uploaded && ct64_uploaded {
-        sqlx::query("SELECT pg_notify($1, '')")
-            .bind(EVENT_CIPHERTEXTS_UPLOADED)
-            .execute(trx.as_mut())
-            .await?;
-
+    if let Some(ct128_bytes) = task.ct128_uncompressed.clone() {
+        let ct128_digest = compute_digest(&ct128_bytes);
         info!(
-            "Uploaded to S3, handle = {}, ct64_digest = {}, ct128_digest = {}",
+            "Uploading ct128, handle: {}, len: {}, tenant: {}",
             handle_as_hex,
-            compact_hex(&ct64_digest),
-            compact_hex(&ct128_digest)
+            ByteSize::b(ct128_bytes.len() as u64),
+            task.tenant_id,
         );
-        telemetry::end_span_with_timestamp(s, upload_finish_time);
-    } else {
-        telemetry::end_span_with_err(
-            s,
-            format!(
-                "Upload failed ct128: {}, ct64: {}",
-                ct128_uploaded, ct64_uploaded
-            ),
-        );
+
+        let key = hex::encode(&ct128_digest);
+        let s = task.otel.child_span("ct128_check_s3");
+        let exists = check_object_exists(client, &conf.bucket_ct128, &key).await?;
+        telemetry::end_span(s);
+
+        if !exists {
+            let mut span: BoxedSpan = task.otel.child_span("ct128_upload_s3");
+            telemetry::attribute(&mut span, "len", ct128_bytes.len().to_string());
+            jobs.push((
+                client
+                    .put_object()
+                    .bucket(conf.bucket_ct128.clone())
+                    .key(key)
+                    .body(ct128_bytes.into())
+                    .send(),
+                UploadResult::CtType128((ct128_digest.clone(), span)),
+            ));
+        }
     }
+
+    if let Some(ct64_compressed) = task.ct64_compressed.clone() {
+        info!(
+            "Uploading ct64, handle: {}, len: {}, tenant: {}",
+            handle_as_hex,
+            ByteSize::b(ct64_compressed.len() as u64),
+            task.tenant_id,
+        );
+
+        let ct64_digest = compute_digest(&ct64_compressed);
+
+        let key = hex::encode(&ct64_digest);
+
+        let s = task.otel.child_span("ct64_check_s3");
+        let exists = check_object_exists(client, &conf.bucket_ct128, &key).await?;
+        telemetry::end_span(s);
+
+        if !exists {
+            let mut span = task.otel.child_span("ct64_upload_s3");
+            telemetry::attribute(&mut span, "len", ct64_compressed.len().to_string());
+            jobs.push((
+                client
+                    .put_object()
+                    .bucket(conf.bucket_ct64.clone())
+                    .key(key)
+                    .body(ct64_compressed.into())
+                    .send(),
+                UploadResult::CtType64((ct64_digest.clone(), span)),
+            ));
+
+            // TODO: Update DB
+        }
+    }
+
+    // Execute all uploads and collect results with their IDs
+    let results: Vec<(Result<_, _>, UploadResult, SystemTime)> = join_all(
+        jobs.into_iter()
+            .map(|(fut, upload)| async move { (fut.await, upload, SystemTime::now()) }),
+    )
+    .await;
+
+    let mut transient_error: Option<ExecutionError> = None;
+
+    for (ct_variant, result, finish_time) in results {
+        match result {
+            UploadResult::CtType128((digest, span)) => {
+                if let Err(err) = ct_variant {
+                    error!(
+                        "Failed to upload ct128, handle: {}, err: {}",
+                        handle_as_hex, err
+                    );
+
+                    telemetry::end_span_with_err(span, err.to_string());
+                    transient_error = Some(ExecutionError::S3TransientError(err.to_string()));
+                } else {
+                    sqlx::query!(
+                        "UPDATE ciphertext_digest
+                        SET ciphertext128 = $1
+                        WHERE handle = $2",
+                        digest,
+                        task.handle
+                    )
+                    .execute(trx.as_mut())
+                    .await?;
+
+                    // Reset ciphertext128 as the ct128 has been successfully uploaded to S3
+                    // NB: For reclaiming the disk-space in DB, we rely on auto vacuuming in
+                    // Postgres
+
+                    sqlx::query!(
+                        "UPDATE ciphertexts
+                        SET ciphertext128 = NULL
+                        WHERE handle = $1",
+                        task.handle
+                    )
+                    .execute(trx.as_mut())
+                    .await?;
+
+                    info!(
+                        "Uploaded ct128, handle: {}, digest: {}",
+                        handle_as_hex,
+                        compact_hex(&digest)
+                    );
+
+                    telemetry::end_span_with_timestamp(span, finish_time);
+                }
+            }
+            UploadResult::CtType64((digest, span)) => {
+                if let Err(err) = ct_variant {
+                    error!(
+                        "Failed to upload ct64, handle: {}, err: {}",
+                        handle_as_hex, err
+                    );
+
+                    telemetry::end_span_with_err(span, err.to_string());
+                    transient_error = Some(ExecutionError::S3TransientError(err.to_string()));
+                } else {
+                    sqlx::query!(
+                        "UPDATE ciphertext_digest
+                            SET ciphertext = $1
+                            WHERE handle = $2",
+                        digest,
+                        task.handle
+                    )
+                    .execute(trx.as_mut())
+                    .await?;
+                    info!(
+                        "Uploaded ct64, handle: {}, digest: {}",
+                        handle_as_hex,
+                        compact_hex(&digest)
+                    );
+
+                    telemetry::end_span_with_timestamp(span, finish_time);
+                }
+            }
+        }
+    }
+
+    // TODO: Move this notify in DB query
+    sqlx::query("SELECT pg_notify($1, '')")
+        .bind(EVENT_CIPHERTEXTS_UPLOADED)
+        .execute(trx.as_mut())
+        .await?;
 
     trx.commit().await?;
 
-    Ok(())
+    transient_error.map_or(Ok(()), Err)
 }
 
 fn compute_digest(ct: &[u8]) -> Vec<u8> {
     let mut hasher = Keccak256::new();
     hasher.update(ct);
     hasher.finalize().to_vec()
+}
+
+/// Fetches incomplete upload tasks from the database.
+async fn fetch_pending_uploads(
+    db_pool: &Pool<Postgres>,
+    limit: i64,
+) -> Result<Vec<HandleItem>, ExecutionError> {
+    let rows = sqlx::query!(
+        "SELECT tenant_id, handle, ciphertext, ciphertext128
+        FROM ciphertext_digest 
+        WHERE ciphertext IS NULL OR ciphertext128 IS NULL
+        FOR UPDATE SKIP LOCKED
+        LIMIT $1;",
+        limit
+    )
+    .fetch_all(db_pool)
+    .await?;
+
+    let mut tasks = Vec::new();
+
+    for row in rows {
+        let mut ct64_compressed: Option<Vec<u8>> = None;
+        let mut ct128_uncompressed: Option<Vec<u8>> = None;
+        let ciphertext_digest = row.ciphertext;
+        let ciphertext128_digest = row.ciphertext128;
+        let handle = row.handle;
+
+        // Fetch missing ciphertext
+        if ciphertext_digest.is_none() {
+            if let Ok(row) = sqlx::query!(
+                "SELECT ciphertext FROM ciphertexts WHERE tenant_id = $1 AND handle = $2;",
+                row.tenant_id,
+                handle
+            )
+            .fetch_optional(db_pool)
+            .await
+            {
+                if let Some(record) = row {
+                    ct64_compressed = Some(record.ciphertext);
+                } else {
+                    error!("Missing ciphertext, handle: {}", hex::encode(&handle));
+                }
+            }
+        }
+
+        // Fetch missing ciphertext128
+        if ciphertext128_digest.is_none() {
+            if let Ok(row) = sqlx::query!(
+                "SELECT ciphertext128 FROM ciphertexts WHERE tenant_id = $1 AND handle = $2;",
+                row.tenant_id,
+                handle
+            )
+            .fetch_optional(db_pool)
+            .await
+            {
+                if let Some(record) = row {
+                    ct128_uncompressed = record.ciphertext128;
+                } else {
+                    error!("Missing ciphertext128, handle: {}", hex::encode(&handle));
+                }
+            }
+        }
+
+        if ct64_compressed.is_some() || ct128_uncompressed.is_some() {
+            tasks.push(HandleItem {
+                tenant_id: row.tenant_id,
+                handle: handle.clone(),
+                ct64_compressed,
+                ct128_uncompressed,
+                otel: telemetry::tracer_with_handle("recovery_task", handle),
+            });
+        }
+    }
+
+    Ok(tasks)
+}
+
+/// Resubmit for uploading ciphertexts.
+/// If a handle has a missing digest in ciphertext_digest table then
+/// retry uploading the actual ciphertext.
+async fn do_resubmits_loop(
+    client: Arc<aws_sdk_s3::Client>,
+    pool: Arc<Pool<Postgres>>,
+    conf: &Config,
+    tasks: mpsc::Sender<HandleItem>,
+    token: CancellationToken,
+    is_ready: Arc<AtomicBool>,
+) -> Result<(), ExecutionError> {
+    // Retry to resubmit all upload tasks at the start-up
+    try_resubmit(&pool, is_ready.clone(), tasks.clone(), token.clone())
+        .await
+        .unwrap_or_else(|err| {
+            error!("Failed to resubmit tasks: {}", err);
+        });
+
+    let retry_conf = &conf.s3.retry_policy;
+
+    loop {
+        select! {
+            _ = token.cancelled() => {
+                return Ok(())
+            },
+            // Recheck S3 ready status
+            _ = tokio::time::sleep(retry_conf.recheck_duration) => {
+                if !is_ready.load(Ordering::SeqCst) {
+                    info!("Recheck S3 setup ...");
+                    let (is_ready_res, _) = check_is_ready(&client, conf).await;
+                    if is_ready_res {
+                        info!("Reconnected to S3, buckets exist");
+                        is_ready.store(true, Ordering::SeqCst);
+                        try_resubmit(&pool, is_ready.clone(), tasks.clone(), token.clone()).await
+                            .unwrap_or_else(|err| {
+                                error!("Failed to resubmit tasks: {}", err);
+                            });
+                    }
+                }
+            }
+
+            // A regular resubmit to ensure there no left over tasks
+
+            _ = tokio::time::sleep(retry_conf.regular_recheck_duration) => {
+                try_resubmit(&pool, is_ready.clone(), tasks.clone(), token.clone()).await
+                    .unwrap_or_else(|err| {
+                        error!("Failed to resubmit tasks: {}", err);
+                    });
+            }
+        }
+    }
+}
+
+async fn try_resubmit(
+    pool: &PgPool,
+    is_ready: Arc<AtomicBool>,
+    tasks: mpsc::Sender<HandleItem>,
+    token: CancellationToken,
+) -> Result<(), ExecutionError> {
+    if !is_ready.load(Ordering::SeqCst) {
+        info!("S3 setup is not ready, skipping resubmit");
+        return Ok(());
+    }
+
+    match fetch_pending_uploads(pool, 10).await {
+        // TODO: const, token
+        Ok(recovery_tasks) => {
+            info!(
+                target: "worker",
+                action = "retry_s3_uploads",
+                "Fetched {} pending uploads from the database",
+                recovery_tasks.len()
+            );
+            // Resubmit for uploading ciphertexts
+            for task in recovery_tasks {
+                select! {
+                    _ = tasks.send(task.clone()) => {
+                        debug!("Task sent to upload worker, handle: {}", hex::encode(&task.handle));
+                    },
+                    _ = token.cancelled() => {
+                        return Ok(())
+                    }
+                }
+            }
+        }
+        Err(err) => error!("Failed to fetch pending uploads: {}", err),
+    };
+    Ok(())
+}
+
+/// Configure and create the S3 client.
+///
+/// Logs errors if the connection fails or if any buckets are missing.
+/// Even in the event of a failure or missing buckets, the function returns a valid
+/// S3 client capable of retrying S3 operations later.
+async fn create_s3_client(conf: &Config) -> (Arc<aws_sdk_s3::Client>, bool) {
+    let s3config = &conf.s3;
+
+    let sdk_config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+    let timeout_config = TimeoutConfig::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .operation_attempt_timeout(s3config.retry_policy.max_retries_timeout)
+        .build();
+
+    let retry_config = RetryConfig::standard()
+        .with_max_attempts(s3config.retry_policy.max_retries_per_upload)
+        .with_max_backoff(s3config.retry_policy.max_backoff);
+
+    let config = Builder::from(&sdk_config)
+        .timeout_config(timeout_config)
+        .retry_config(retry_config)
+        .build();
+
+    let client = Arc::new(Client::from_conf(config));
+    let (is_ready, is_connected) = check_is_ready(&client, conf).await;
+    if is_connected {
+        info!("Connected to S3, is_ready: {}", is_ready);
+    }
+
+    (client, is_ready)
+}
+
+/// Checks if the S3 client is ready by verifying the existence of both
+/// the ct64 and ct128 buckets.
+///
+/// Returns is_ready and is_connected status.
+async fn check_is_ready(client: &Client, conf: &Config) -> (bool, bool) {
+    // Check if the S3 client is ready
+    //
+    // By checking the existence of both ct64 and ct128 buckets here,
+    // we also incorporate the aws-sdk connection retry
+    let (ct64_exists, _) = check_bucket_exists(client, &conf.s3.bucket_ct64).await;
+    let (ct128_exists, conn) = check_bucket_exists(client, &conf.s3.bucket_ct128).await;
+
+    ((ct64_exists && ct128_exists), conn)
+}
+
+async fn check_object_exists(
+    client: &Client,
+    bucket: &str,
+    key: &str,
+) -> Result<bool, ExecutionError> {
+    match client.head_object().bucket(bucket).key(key).send().await {
+        Ok(_) => Ok(true),
+        Err(SdkError::ServiceError(err)) if matches!(err.err(), HeadObjectError::NotFound(_)) => {
+            Ok(false)
+        }
+        Err(err) => {
+            error!("Failed to check object existence: {}", err);
+            Err(ExecutionError::S3TransientError(err.to_string()))
+        }
+    }
+}
+
+async fn check_bucket_exists(
+    client: &Client,
+    bucket: &str,
+) -> (bool, bool /* connection status */) {
+    let res: Result<bool, SdkError<HeadBucketError, _>> =
+        match client.head_bucket().bucket(bucket).send().await {
+            Ok(_) => Ok(true),
+            Err(SdkError::ServiceError(err))
+                if matches!(err.err(), HeadBucketError::NotFound(_)) =>
+            {
+                Ok(false)
+            }
+            Err(err) => {
+                error!("Failed to check bucket existence: {}", err);
+                Err(err)
+            }
+        };
+
+    match res {
+        Ok(true) => {
+            info!("Bucket {} exists", bucket);
+            (true, true)
+        }
+        Ok(false) => {
+            error!({ action = "review" }, "Bucket {} does not exist", bucket);
+            (false, true)
+        }
+        Err(err) => {
+            error!(
+                { action = "review" },
+                "Failed to check bucket existence: {:?}", err
+            );
+            (false, false)
+        }
+    }
 }

--- a/fhevm-engine/sns-executor/src/bin/sns_worker.rs
+++ b/fhevm-engine/sns-executor/src/bin/sns_worker.rs
@@ -36,13 +36,14 @@ fn construct_config() -> Config {
             bucket_ct128: args.bucket_name_ct128,
             bucket_ct64: args.bucket_name_ct64,
             max_concurrent_uploads: args.max_concurrent_uploads,
+            retry_policy: S3Config::default().retry_policy, // TODO:
         },
     }
 }
 
 #[tokio::main]
 async fn main() {
-    let conf: Config = construct_config();
+    let config: Config = construct_config();
     let parent = CancellationToken::new();
 
     tracing_subscriber::fmt()
@@ -58,23 +59,26 @@ async fn main() {
     // to avoid blocking the worker
     // and to allow for some burst of uploads
     let (uploads_tx, uploads_rx) =
-        mpsc::channel::<HandleItem>(10 * conf.s3.max_concurrent_uploads as usize);
+        mpsc::channel::<HandleItem>(10 * config.s3.max_concurrent_uploads as usize);
 
-    let config = conf.clone();
-    let token = parent.child_token();
-
-    if let Err(err) = telemetry::setup_otlp(&conf.service_name) {
+    if let Err(err) = telemetry::setup_otlp(&config.service_name) {
         panic!("Error while initializing tracing: {:?}", err);
     }
 
+    let conf = config.clone();
+    let token = parent.child_token();
+    let tx = uploads_tx.clone();
     spawn(async move {
-        if let Err(err) = process_s3_uploads(&config, uploads_rx, token).await {
+        if let Err(err) = process_s3_uploads(&conf, uploads_rx, tx, token).await {
             error!("Failed to run the upload-worker : {:?}", err);
         }
     });
 
     // Start the SnS worker
-    if let Err(err) = compute_128bit_ct(&conf, uploads_tx, parent.child_token()).await {
+
+    let conf = config.clone();
+    let token = parent.child_token();
+    if let Err(err) = compute_128bit_ct(&conf, uploads_tx, token).await {
         error!("SnS worker failed: {:?}", err);
     }
 }

--- a/fhevm-engine/sns-executor/src/executor.rs
+++ b/fhevm-engine/sns-executor/src/executor.rs
@@ -187,8 +187,8 @@ async fn query_sns_tasks(
         .map(|record| HandleItem {
             tenant_id: record.tenant_id,
             handle: record.handle.clone(),
-            ct64_compressed: record.ciphertext,
-            ct128_uncompressed: None,
+            ct64_compressed: Some(record.ciphertext),
+            ct128_uncompressed: None, // to be computed
             otel: telemetry::tracer_with_handle("task", record.handle),
         })
         .collect();
@@ -237,8 +237,15 @@ fn process_tasks(
     set_server_key(keys.server_key.clone());
 
     for task in tasks.iter_mut() {
+        let ct64_compressed = task.ct64_compressed.as_ref().ok_or_else(|| {
+            ExecutionError::MissingCiphertext128(format!(
+                "Missing ct64_compressed for handle: {}",
+                hex::encode(&task.handle)
+            ))
+        })?;
+
         let s = task.otel.child_span("decompress_ct64");
-        let ct = decompress_ct(&task.handle, &task.ct64_compressed)?;
+        let ct = decompress_ct(&task.handle, ct64_compressed)?;
         telemetry::end_span(s);
 
         let handle = compact_hex(&task.handle);
@@ -285,8 +292,10 @@ fn process_tasks(
             // 2. The input channel of the upload worker (size: conf.max_concurrent_uploads * 10)
             // 3. The PostgresDB (size: unlimited)
 
-            error!({targe = "worker", action = "review"},  "Failed to send task to upload worker: {err}");
+            error!({target = "worker", action = "review"},  "Failed to send task to upload worker: {err}");
             telemetry::end_span_with_err(task.otel.child_span("send_task"), err.to_string());
+
+            // TODO: Insert ciphertext
         }
     }
 
@@ -309,11 +318,20 @@ async fn update_ciphertext128(
     for task in tasks {
         if let Some(ciphertext128) = &task.ct128_uncompressed {
             let s = task.otel.child_span("ct128_db_insert");
+
+            // Insert the ciphertext128 into the database only if
+            // the uploader has not already put it in AWS S3
             let res = sqlx::query!(
                 "
                 UPDATE ciphertexts
                 SET ciphertext128 = $1
-                WHERE handle = $2;",
+                WHERE handle = $2
+                AND EXISTS (
+                    SELECT 1
+                    FROM ciphertext_digest
+                    WHERE handle = $2
+                        AND ciphertext128 IS NULL
+                );",
                 ciphertext128,
                 task.handle
             )


### PR DESCRIPTION
- Enable retry policy for AWS S3 client
- Add health-checking (ready/non-ready S3 setup state)
- Resubmit upload jobs once S3 setup readiness is recovered
- Ensure the failed S3 (put_objects) operations are re-queued in the DB
- Ensure already uploaded ciphertexts are not re-uploaded

fixes #413 
